### PR TITLE
chore(aurora-signal): make AuroraSignalSession async

### DIFF
--- a/packages/aurora-signal/src/client.ts
+++ b/packages/aurora-signal/src/client.ts
@@ -7,7 +7,7 @@ interface RequestParams {
     host?: string
     headers?: Record<string, string>
     body?: string | object
-    queryParams?: Record<string, string | number | boolean | object | undefined>
+    queryParams?: Record<string, string | string[] | number | boolean | null | undefined>
     debug?: boolean
   }
 }
@@ -30,18 +30,14 @@ const buildRequestUrl = function ({ base, path }: { base?: string; path?: string
 }
 
 function buildSearchParams(params: NonNullable<RequestParams["options"]>["queryParams"]): string {
-  const searchParams = new URLSearchParams()
-
-  for (const key in params) {
-    const value = params[key]
-    if (Array.isArray(value)) {
-      value.forEach((item) => searchParams.append(key, item.toString())) // Repeated key format
-    } else if (value !== undefined) {
-      searchParams.append(key, value.toString())
-    }
-  }
-
-  return searchParams.toString()
+  if (!params) return ""
+  return new URLSearchParams(
+    Object.entries(params)
+      .filter(([, value]) => value != null) // Remove null & undefined
+      .flatMap(([key, value]) =>
+        Array.isArray(value) ? value.map((v) => [key, v.toString()]) : [[key, value!.toString()]]
+      )
+  ).toString()
 }
 
 const request = ({ method, path, options = {} }: RequestParams) => {


### PR DESCRIPTION
# Summary

This PR improves AuroraSignalSession by making the main function asynchronous, requiring an await when initializing it. However, all internal public functions can be called synchronously afterward without additional waiting.

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
