### PR TITLE
chore(signal-openstack): parse api response errors

### DIFF
--- a/packages/signal-openstack/src/client.test.ts
+++ b/packages/signal-openstack/src/client.test.ts
@@ -55,7 +55,7 @@ describe("client", () => {
     })
 
     it("should throw an error if the response is not ok", async () => {
-      global.fetch = vi.fn().mockResolvedValue({ ok: false, statusText: "error", status: 500 })
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, statusText: "error", status: 500, json: vi.fn() })
       await expect(client.get("/", { host: "http://localhost" })).rejects.toThrow("error")
     })
   })
@@ -106,7 +106,7 @@ describe("client", () => {
     })
 
     it("should throw an error if the response is not ok", async () => {
-      global.fetch = vi.fn().mockResolvedValue({ ok: false, statusText: "error", status: 500 })
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, statusText: "error", status: 500, json: vi.fn() })
       await expect(client.head("/", { host: "http://localhost" })).rejects.toThrow("error")
     })
 
@@ -155,7 +155,7 @@ describe("client", () => {
     })
 
     it("should throw an error if the response is not ok", async () => {
-      global.fetch = vi.fn().mockResolvedValue({ ok: false, statusText: "error", status: 500 })
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, statusText: "error", status: 500, json: vi.fn() })
       await expect(client.head("/", { host: "http://localhost" })).rejects.toThrow("error")
     })
   })
@@ -206,7 +206,7 @@ describe("client", () => {
     })
 
     it("should throw an error if the response is not ok", async () => {
-      global.fetch = vi.fn().mockResolvedValue({ ok: false, statusText: "error", status: 500 })
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, statusText: "error", status: 500, json: vi.fn() })
       await expect(client.del("/", { host: "http://localhost" })).rejects.toThrow("error")
     })
 

--- a/packages/signal-openstack/src/client.test.ts
+++ b/packages/signal-openstack/src/client.test.ts
@@ -56,7 +56,7 @@ describe("client", () => {
 
     it("should throw an error if the response is not ok", async () => {
       global.fetch = vi.fn().mockResolvedValue({ ok: false, statusText: "error", status: 500 })
-      await expect(client.get("/", { host: "http://localhost" })).rejects.toThrow("SignalOpenstackApiError: error")
+      await expect(client.get("/", { host: "http://localhost" })).rejects.toThrow("error")
     })
   })
 
@@ -107,7 +107,7 @@ describe("client", () => {
 
     it("should throw an error if the response is not ok", async () => {
       global.fetch = vi.fn().mockResolvedValue({ ok: false, statusText: "error", status: 500 })
-      await expect(client.head("/", { host: "http://localhost" })).rejects.toThrow("SignalOpenstackApiError: error")
+      await expect(client.head("/", { host: "http://localhost" })).rejects.toThrow("error")
     })
 
     it("should return a promise", async () => {
@@ -156,7 +156,7 @@ describe("client", () => {
 
     it("should throw an error if the response is not ok", async () => {
       global.fetch = vi.fn().mockResolvedValue({ ok: false, statusText: "error", status: 500 })
-      await expect(client.head("/", { host: "http://localhost" })).rejects.toThrow("SignalOpenstackApiError: error")
+      await expect(client.head("/", { host: "http://localhost" })).rejects.toThrow("error")
     })
   })
 
@@ -207,7 +207,7 @@ describe("client", () => {
 
     it("should throw an error if the response is not ok", async () => {
       global.fetch = vi.fn().mockResolvedValue({ ok: false, statusText: "error", status: 500 })
-      await expect(client.del("/", { host: "http://localhost" })).rejects.toThrow("SignalOpenstackApiError: error")
+      await expect(client.del("/", { host: "http://localhost" })).rejects.toThrow("error")
     })
 
     it("should log debug info", async () => {

--- a/packages/signal-openstack/src/client.ts
+++ b/packages/signal-openstack/src/client.ts
@@ -65,7 +65,7 @@ const request = ({ method, path, options = {} }: RequestParams) => {
       }
     })
     .catch((error) => {
-      throw new SignalOpenstackApiError(error.message)
+      throw new SignalOpenstackApiError(error.message, 500)
     })
 }
 

--- a/packages/signal-openstack/src/client.ts
+++ b/packages/signal-openstack/src/client.ts
@@ -1,3 +1,4 @@
+import { parseErrorObject } from "./responseErrorHandler"
 import { SignalOpenstackError, SignalOpenstackApiError } from "./error"
 
 interface RequestParams {
@@ -57,11 +58,13 @@ const request = ({ method, path, options = {} }: RequestParams) => {
     method,
     body,
   })
-    .then((response) => {
+    .then(async (response) => {
       if (response.ok) {
         return response
       } else {
-        throw new SignalOpenstackApiError(response.statusText, response.status)
+        const errorObject = await response.json()
+        const parsedError = parseErrorObject(errorObject)
+        throw new SignalOpenstackApiError(parsedError || response.statusText, response.status)
       }
     })
     .catch((error) => {

--- a/packages/signal-openstack/src/error.test.ts
+++ b/packages/signal-openstack/src/error.test.ts
@@ -14,7 +14,7 @@ describe("SignalOpenstackError", () => {
   })
 
   it("should contain a message starting with SignalOpenstack SignalOpenstackError: ", async () => {
-    expect(new SignalOpenstackError("test").message).toContain("SignalOpenstackError: ")
+    expect(new SignalOpenstackError("test").message).toContain("test")
   })
 })
 
@@ -32,7 +32,7 @@ describe("SignalOpenstackApiError", () => {
   })
 
   it("should contain a message starting with SignalOpenstack SignalOpenstackApiError: ", async () => {
-    expect(new SignalOpenstackApiError("test").message).toContain("SignalOpenstackApiError: ")
+    expect(new SignalOpenstackApiError("test").message).toContain("test")
   })
 
   it("should respond to statusCode", async () => {

--- a/packages/signal-openstack/src/error.ts
+++ b/packages/signal-openstack/src/error.ts
@@ -1,6 +1,6 @@
 export class SignalOpenstackError extends Error {
   constructor(message: string) {
-    super("SignalOpenstackError: " + message)
+    super(message)
     this.name = "SignalOpenstackError"
   }
 }
@@ -9,7 +9,7 @@ export class SignalOpenstackApiError extends Error {
   statusCode?: number
 
   constructor(message: string, statusCode?: number) {
-    super("SignalOpenstackApiError: " + message)
+    super(message)
     this.name = "SignalOpenstackApiError"
     this.statusCode = statusCode
   }

--- a/packages/signal-openstack/src/responseErrorHandler.test.ts
+++ b/packages/signal-openstack/src/responseErrorHandler.test.ts
@@ -1,0 +1,63 @@
+import { parseErrorObject } from "./responseErrorHandler"
+
+describe("responseErrorHandler", () => {
+  it("should return null for undefined input", () => {
+    expect(parseErrorObject(undefined)).toBeNull()
+  })
+
+  it("should return null for null input", () => {
+    expect(parseErrorObject(null)).toBeNull()
+  })
+
+  it("should return a string when passed a string directly", () => {
+    const errorMessage = "This is a string error message."
+    expect(parseErrorObject(errorMessage)).toBe(errorMessage)
+  })
+
+  it("should parse a simple error object and return the message", () => {
+    const errorObject = {
+      message: "Unauthorized access",
+    }
+    expect(parseErrorObject(errorObject)).toBe("Unauthorized access")
+  })
+
+  it("should parse a complex error object and return the first available message", () => {
+    const errorObject = {
+      type: "authentication",
+      message: "Unauthorized access",
+      description: "You are not logged in",
+    }
+    expect(parseErrorObject(errorObject)).toBe("Unauthorized access")
+  })
+
+  it("should return the first found message from the complex structure", () => {
+    const errorObject = {
+      faultstring: "Some error",
+      details: {
+        message: "Actual message shows here",
+      },
+    }
+    expect(parseErrorObject(errorObject)).toBe("Some error")
+  })
+
+  test("parseErrorObject", () => {
+    const errorObject = { error: { code: 401, message: "TEST.", title: "Unauthorized" } }
+    expect(parseErrorObject(errorObject)).toEqual("TEST.")
+  })
+
+  it("should parse and return the faultstring if no other messages are found", () => {
+    const errorObject = {
+      faultstring: "An unexpected error occurred",
+    }
+    expect(parseErrorObject(errorObject)).toBe("An unexpected error occurred")
+  })
+
+  it("should return concatenated messages from objects", () => {
+    const errorObject = {
+      error1: { message: "First error message" },
+      error2: { message: "Second error message" },
+      error3: { faultstring: "Third error message" },
+    }
+    expect(parseErrorObject(errorObject)).toBe("First error message, Second error message, Third error message")
+  })
+})

--- a/packages/signal-openstack/src/responseErrorHandler.ts
+++ b/packages/signal-openstack/src/responseErrorHandler.ts
@@ -1,0 +1,48 @@
+import { z, ZodError } from "zod"
+
+// Define the schema for the error object
+const ErrorObjectSchema = z.object({
+  message: z.string().optional(),
+  description: z.string().optional(),
+  type: z.string().optional(),
+  faultstring: z.string().optional(),
+})
+
+// Create a function to handle parsing of the error object
+export function parseErrorObject(object: unknown): string | null {
+  if (!object) return null
+
+  // If the object is a string, return it directly
+  if (typeof object === "string") return object
+
+  // If the object is an array, recursively parse each item and join the results
+  if (Array.isArray(object)) {
+    return object.map(parseErrorObject).filter(Boolean).join(", ")
+  }
+
+  // Ensure we assert that object is indeed a Record for TypeScript to understand its structure
+  const typedObject = object as Record<string, unknown>
+
+  // Attempt to parse and extract the error message from a structured object
+  try {
+    const parsed = ErrorObjectSchema.parse(typedObject) // Validate and parse the object
+
+    // Return the first defined message in priority order
+    const errorMessage = parsed.message || parsed.description || parsed.faultstring || parsed.type
+
+    if (errorMessage) {
+      return errorMessage
+    }
+
+    // If no message is found, iterate through the object keys to find additional messages
+    return Object.keys(typedObject)
+      .map((key) => parseErrorObject(typedObject[key])) // Accessing the key safely
+      .filter(Boolean) // Filter out null results from parsing
+      .join(", ")
+  } catch (e) {
+    if (e instanceof ZodError) {
+      console.error("Invalid error object structure:", e.errors)
+    }
+    return null // Return null if parsing fails
+  }
+}

--- a/packages/signal-openstack/src/service.test.ts
+++ b/packages/signal-openstack/src/service.test.ts
@@ -101,7 +101,7 @@ describe("service", () => {
     it("should throw error for unknown region", async () => {
       const service = SignalOpenstackService("service1", token, { region: "region1" })
       await expect(service.get("path", {})).rejects.toThrow(
-        "SignalOpenstackError: Service service1 (region: region1, interface: public) not found."
+        "Service service1 (region: region1, interface: public) not found."
       )
     })
 
@@ -113,7 +113,7 @@ describe("service", () => {
     it("should throw error for unknown interface", async () => {
       const service = SignalOpenstackService("service1", token, { region: "region", interfaceName: "unknown" })
       await expect(service.get("path", {})).rejects.toThrow(
-        "SignalOpenstackError: Service service1 (region: region, interface: unknown) not found."
+        "Service service1 (region: region, interface: unknown) not found."
       )
     })
 


### PR DESCRIPTION
# Summary

This Pull Request (PR) adds an error parser to the `signal-openstack` package. In the case of failures from the OpenStack API, the response returns an error JSON object that contains the error message. Unfortunately, the JSON structure and keys are not standardized across all OpenStack services, necessitating the search for specific keywords within the JSON.

This functionality enhances the user experience by providing more detailed error messages.

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
