### PR TITLE
chore(dashboard): stringify zod errors

### DIFF
--- a/apps/aurora-portal/src/server/server.ts
+++ b/apps/aurora-portal/src/server/server.ts
@@ -32,7 +32,7 @@ async function startServer() {
       createContext, // Pass the context
       onError: (err) => {
         // handle ZodError messages
-        //
+        // combine all error messages into a single string
         if (err.error.cause instanceof ZodError)
           err.error.message = err.error.cause.errors.map((e) => e.message).join(",")
       },

--- a/apps/aurora-portal/src/server/server.ts
+++ b/apps/aurora-portal/src/server/server.ts
@@ -1,15 +1,12 @@
 import Fastify from "fastify"
 import FastifyStatic from "@fastify/static"
 import cookie from "@fastify/cookie"
-import {
-  AuroraFastifyTRPCPluginOptions,
-  AuroraTRPCError,
-  auroraFastifyTRPCPlugin,
-} from "@cobaltcore-dev/aurora-sdk/server"
+import { AuroraFastifyTRPCPluginOptions, auroraFastifyTRPCPlugin } from "@cobaltcore-dev/aurora-sdk/server"
 import { appRouter, AuroraRouter } from "./routers" // tRPC router
 import { createContext } from "./context"
 import * as dotenv from "dotenv"
 import path from "path"
+import { ZodError } from "zod"
 
 dotenv.config()
 
@@ -33,6 +30,12 @@ async function startServer() {
     trpcOptions: {
       router: appRouter, // Pass the tRPC router to handle routes
       createContext, // Pass the context
+      onError: (err) => {
+        // handle ZodError messages
+        //
+        if (err.error.cause instanceof ZodError)
+          err.error.message = err.error.cause.errors.map((e) => e.message).join(",")
+      },
     } satisfies AuroraFastifyTRPCPluginOptions<AuroraRouter>["trpcOptions"], // Type-safety to ensure proper config
   })
 
@@ -52,23 +55,10 @@ async function startServer() {
   }
 
   await server.setErrorHandler((error, request, reply) => {
-    server.log.error(error)
-
-    // For tRPC errors
-    if (error instanceof AuroraTRPCError) {
-      reply.status(400).send({
-        status: error.code || "error",
-        statusCode: 400,
-        message: error.message || "A tRPC error occurred",
-      })
-    } else {
-      // For generic errors
-      reply.status(500).send({
-        status: "error",
-        statusCode: error.code || 500,
-        message: error.message || "Internal Server Error",
-      })
-    }
+    reply.status(error.statusCode || 500).send({
+      status: error.code || "Internal Server Error",
+      message: error.message || "Internal Server Error",
+    })
   })
 
   await server.listen({ host: "0.0.0.0", port: Number(PORT) }).then((address) => {


### PR DESCRIPTION
# Summary

Utilize the `onError` callback in the tRPC Fastify plugin to intercept Zod errors. Zod errors contain an array of validation messages, but tRPC simply stringifies these errors, making them difficult to handle in the user interface. 

This Pull Request (PR) collects all validation messages and combines them into a single string separated by commas. This approach allows us to display validation errors directly as strings or to implement more advanced formatting as needed.



# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
