### PR TITLE
feat(chore): do the rescoping on the bff side

### DIFF
--- a/apps/aurora-portal/src/client/Auth/AuthMenu.test.tsx
+++ b/apps/aurora-portal/src/client/Auth/AuthMenu.test.tsx
@@ -30,8 +30,6 @@ describe("AuthMenu Component", () => {
     terminateUserSession: { mutate: vi.fn() },
     createUserSession: { mutate: vi.fn() },
     getAuthToken: { query: vi.fn() },
-    setCurrentProject: { mutate: vi.fn() },
-    setCurrentDomain: { mutate: vi.fn() },
   }
 
   beforeEach(() => {

--- a/apps/aurora-portal/src/client/Auth/AuthMenu.test.tsx
+++ b/apps/aurora-portal/src/client/Auth/AuthMenu.test.tsx
@@ -30,6 +30,7 @@ describe("AuthMenu Component", () => {
     terminateUserSession: { mutate: vi.fn() },
     createUserSession: { mutate: vi.fn() },
     getAuthToken: { query: vi.fn() },
+    getCurrentScope: { query: vi.fn() },
   }
 
   beforeEach(() => {

--- a/apps/aurora-portal/src/client/Auth/SignIn.test.tsx
+++ b/apps/aurora-portal/src/client/Auth/SignIn.test.tsx
@@ -16,8 +16,6 @@ describe("SignIn Component", () => {
     getCurrentUserSession: { query: vi.fn() },
     terminateUserSession: { mutate: vi.fn() },
     getAuthToken: { query: vi.fn() },
-    setCurrentProject: { mutate: vi.fn() },
-    setCurrentDomain: { mutate: vi.fn() },
   }
 
   beforeEach(() => {

--- a/apps/aurora-portal/src/client/Auth/SignIn.test.tsx
+++ b/apps/aurora-portal/src/client/Auth/SignIn.test.tsx
@@ -16,6 +16,7 @@ describe("SignIn Component", () => {
     getCurrentUserSession: { query: vi.fn() },
     terminateUserSession: { mutate: vi.fn() },
     getAuthToken: { query: vi.fn() },
+    getCurrentScope: { query: vi.fn() },
   }
 
   beforeEach(() => {

--- a/apps/aurora-portal/src/client/Compute/ComputeOverview.tsx
+++ b/apps/aurora-portal/src/client/Compute/ComputeOverview.tsx
@@ -25,18 +25,19 @@ export function ComputeOverview({ client }: { client: TrpcClient }) {
   const { setCurrentProject } = useAuroraContext()
 
   const [viewMode, setViewMode] = useState<"list" | "card">("list")
-  const params = useParams()
+  const { projectId } = useParams()
 
   useEffect(() => {
-    client.compute.getServers
-      .query()
+    if (!projectId) return
+    client.compute.getServersByProjectId
+      .query({ projectId })
       .then((data) => updateGetServer({ data, isLoading: false }))
       .catch((error) => updateGetServer({ error: error.message, isLoading: false }))
   }, [])
 
   useEffect(() => {
     client.project.getProjectById
-      .query({ id: params?.projectId || "" })
+      .query({ id: projectId || "" })
       .then((data) => {
         setCurrentProject(data)
         return updateProjectById({ data, isProjectLoading: false })

--- a/apps/aurora-portal/src/client/Project/ProejctsOverview.tsx
+++ b/apps/aurora-portal/src/client/Project/ProejctsOverview.tsx
@@ -20,7 +20,7 @@ export function ProjectsOverview({ client }: { client: TrpcClient["project"] }) 
   const [viewMode, setViewMode] = useState<ViewMode>("card")
 
   useEffect(() => {
-    client.authProjects
+    client.getAuthProjects
       .query()
       .then((data) => updateGetProjects({ data, isLoading: false }))
       .catch((error) => updateGetProjects({ error: error.message, isLoading: false }))

--- a/apps/aurora-portal/src/server/Authentication/routers/sessionRouter.ts
+++ b/apps/aurora-portal/src/server/Authentication/routers/sessionRouter.ts
@@ -13,6 +13,19 @@ export const sessionRouter = {
     return token?.authToken || null
   }),
 
+  getCurrentScope: publicProcedure.query(async ({ ctx }) => {
+    const token = ctx.openstack?.getToken()
+    if (!token) {
+      return null
+    }
+    const project = token.tokenData.project
+    const domain = project?.domain || token.tokenData.domain
+    return {
+      project: project,
+      domain: domain,
+    }
+  }),
+
   createUserSession: publicProcedure
     .input(z.object({ user: z.string(), password: z.string(), domainName: z.string() }))
     .mutation(async ({ input, ctx }) => {

--- a/apps/aurora-portal/src/server/Authentication/routers/sessionRouter.ts
+++ b/apps/aurora-portal/src/server/Authentication/routers/sessionRouter.ts
@@ -8,16 +8,6 @@ export const sessionRouter = {
     return token?.tokenData || null
   }),
 
-  setCurrentProject: publicProcedure.input(z.string()).mutation(async ({ input, ctx }) => {
-    const openstackSession = await ctx.rescopeSession({ project: { id: input } })
-    return openstackSession?.getToken()?.tokenData || null
-  }),
-
-  setCurrentDomain: publicProcedure.input(z.string()).mutation(async ({ input, ctx }) => {
-    const openstackSession = await ctx.rescopeSession({ domain: { id: input } })
-    return openstackSession?.getToken()?.tokenData || null
-  }),
-
   getAuthToken: publicProcedure.query(async ({ ctx }) => {
     const token = ctx.openstack?.getToken()
     return token?.authToken || null

--- a/apps/aurora-portal/src/server/Compute/routers/serverRouter.ts
+++ b/apps/aurora-portal/src/server/Compute/routers/serverRouter.ts
@@ -159,7 +159,17 @@ export const serverRouter = {
     return sampleServers[input.id]
   }),
 
-  getServers: protectedProcedure.query((): Server[] => {
+  getMockServers: protectedProcedure.query((): Server[] => {
     return sampleServers
+  }),
+
+  getServersByProjectId: protectedProcedure.input(z.object({ projectId: z.string() })).query(async ({ input, ctx }) => {
+    const openstackSession = await ctx.rescopeSession({ projectId: input.projectId })
+    const compute = openstackSession?.service("compute")
+    if (!compute) {
+      throw new Error("Compute service not available")
+    }
+    const { servers } = await compute.get("servers/detail").then((res) => res.json())
+    return servers as Server[]
   }),
 }

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -23,6 +23,7 @@ export const scopes = [
   "aurora-sdk",
   "signal-openstack",
   "polaris",
+  "bff",
   "docs",
   "deps",
   "infra",


### PR DESCRIPTION
# Summary

Instead of rescoping the OpenStack token in the UI and performing a back-and-forth communication with the backend-for-frontend (BFF), we now rescope the token directly within the BFF. This is done explicitly in each router function when necessary.

# Changes Made

- Extended the `rescopeSession` function in the context to cache the scope and rescope only if the scope has changed.
- Called the `rescopeSession` function in the router functions. For example, to retrieve the `authProjects`, the scope should be rescoped to the domain.


# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
