### PR TITLE
chore(core): adds missing permissions to workflows

### DIFF
--- a/.github/workflows/ci-title-lint-check.yaml
+++ b/.github/workflows/ci-title-lint-check.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   pull-requests: read
+  statuses: write
 
 jobs:
   title-lint:

--- a/.github/workflows/ci-title-lint-check.yaml
+++ b/.github/workflows/ci-title-lint-check.yaml
@@ -8,6 +8,10 @@ on:
       - synchronize
       - reopened
 
+permissions:
+  pull-requests: read
+  statuses: write
+
 jobs:
   title-lint:
     name: Validate PR title

--- a/.github/workflows/ci-title-lint-check.yaml
+++ b/.github/workflows/ci-title-lint-check.yaml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   pull-requests: read
-  statuses: write
 
 jobs:
   title-lint:

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -6,6 +6,10 @@ name: REUSE Compliance Check
 
 on: [pull_request]
 
+permissions:
+  contents: read # Needed to access repo files for linting
+  pull-requests: read # Needed to access PR metadata (e.g., changed files) 
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary

Fixes `Workflow does not contain permissions` for  workflow `ci-title-lint-check` and `reuse`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
