### PR TITLE
fix(ui): prevent loading spinner from showing on search parameter changes

### DIFF
--- a/apps/aurora-portal/src/client/routes/__root.tsx
+++ b/apps/aurora-portal/src/client/routes/__root.tsx
@@ -23,18 +23,23 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
 })
 
 function AuroraLayout({ mainNavItems = [] }: NavigationLayoutProps) {
-  const isPending = useRouterState({ select: (s) => s.status === "pending" })
+  // More specific selector to check if we're actually navigating to a different route
+  const routerState = useRouterState()
+  const isNavigating =
+    routerState.status === "pending" && routerState.location.pathname !== routerState?.resolvedLocation?.pathname
+
   const [isLoading, setIsLoading] = useState(false)
+
   useEffect(() => {
-    // Set loading state based on router status
-    if (isPending) {
+    // Only show loading spinner for actual route changes, not search parameter changes
+    if (isNavigating) {
       setIsLoading(true)
     } else {
       setTimeout(() => {
         setIsLoading(false)
-      }, 300) // Delay to show spinner for at least 1 second
+      }, 300) // Delay to show spinner for at least 300ms
     }
-  }, [isPending, isLoading, setIsLoading])
+  }, [isNavigating, isLoading, setIsLoading])
 
   // Default navigation items
   const defaultItems: NavigationItem[] = [


### PR DESCRIPTION
# Summary

## Problem

The loading spinner was being triggered whenever search parameters changed (e.g., `?param=value`), even though the user remained on the same page. This created a poor user experience with unnecessary loading states during URL parameter updates.

## Root Cause

The previous implementation checked only for `routerState.status === "pending"`, which TanStack Router sets to `true` for any route transition, including search parameter changes.

## Solution

Updated the loading state logic to be more specific about when to show the spinner:

 - **Before:** Show spinner on any router pending state
 - **After:** Show spinner only when actually navigating to a different route (pathname change)

# Changes Made

<!-- List the changes that were made in this pull request. -->

 - **Enhanced router state detection:** Added pathname comparison to distinguish between route changes and search parameter updates
 - **Improved condition logic:** Now checks for `routerState.status === "pending"` AND pathname differences

**Note:** It needs to be tested on UI.

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- Issue 1: [link to issue]

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
