### PR TITLE
feat(app-gardener): implement delete modal

### DIFF
--- a/apps/aurora-portal/src/client/routes/gardener/-components/ClusterDetail/DetailLayout.test.tsx
+++ b/apps/aurora-portal/src/client/routes/gardener/-components/ClusterDetail/DetailLayout.test.tsx
@@ -23,6 +23,33 @@ describe("DetailLayout", () => {
     onBack: vi.fn(),
     handleShare: vi.fn(),
     children: <div data-testid="test-children">Test children content</div>,
+    cluster: {
+      uid: "test-cluster-123",
+      name: "test-cluster",
+      infrastructure: "aws",
+      region: "us-east-1",
+      status: "Operational",
+      version: "1.28.5",
+      readiness: {
+        status: "5/5",
+        conditions: [],
+      },
+      workers: [],
+      maintenance: {
+        startTime: "030000+0000",
+        timezone: "UTC",
+        windowTime: "040000+0000",
+      },
+      lastMaintenance: {
+        state: "Succeeded",
+      },
+      autoUpdate: {
+        os: true,
+        kubernetes: true,
+      },
+    },
+    setDeleteClusterModal: vi.fn(),
+    setDeleteClusterName: vi.fn(),
   }
 
   beforeEach(async () => {

--- a/apps/aurora-portal/src/client/routes/gardener/-components/ClusterDetail/DetailLayout.tsx
+++ b/apps/aurora-portal/src/client/routes/gardener/-components/ClusterDetail/DetailLayout.tsx
@@ -1,7 +1,16 @@
 import React, { ReactNode } from "react"
-import { Stack, Breadcrumb, BreadcrumbItem, ContentHeading, Button } from "@cloudoperators/juno-ui-components"
+import {
+  Stack,
+  Breadcrumb,
+  BreadcrumbItem,
+  ContentHeading,
+  Button,
+  ButtonRow,
+} from "@cloudoperators/juno-ui-components"
+import { useLingui } from "@lingui/react/macro"
 
 import ViewToggleButtons from "../ClusterDetail/ViewToggleButtons"
+import { Cluster } from "@/server/Gardener/types/cluster"
 
 export interface DetailLayoutProps {
   title: string
@@ -10,9 +19,13 @@ export interface DetailLayoutProps {
   breadcrumbActiveLabel: string
   isJsonView: boolean
   children: ReactNode
+  cluster: Cluster
   toggleView: () => void
   onBack: () => void
   handleShare: () => void
+
+  setDeleteClusterModal: (isShown: boolean) => void
+  setDeleteClusterName: (clusterName: string) => void
 }
 
 export const Views = {
@@ -30,9 +43,12 @@ const DetailLayout: React.FC<DetailLayoutProps> = ({
   isJsonView,
   toggleView,
   children,
+  cluster,
+  setDeleteClusterModal,
+  setDeleteClusterName,
 }) => {
   const viewType = isJsonView ? Views.JSON : Views.GRID
-
+  const { t } = useLingui()
   return (
     <Stack direction="vertical">
       <Breadcrumb>
@@ -46,7 +62,18 @@ const DetailLayout: React.FC<DetailLayoutProps> = ({
           {description && <p className="text-theme-default text-sm mt-1">{description}</p>}
         </Stack>
         <Stack direction="vertical" distribution="center">
-          <Button label="Share" icon="contentCopy" variant="primary" onClick={handleShare} />
+          <ButtonRow>
+            <Button
+              label={t`Delete`}
+              icon="deleteForever"
+              variant="primary-danger"
+              onClick={() => {
+                setDeleteClusterName(cluster.name)
+                setDeleteClusterModal(true)
+              }}
+            />
+            <Button label={t`Share`} icon="contentCopy" variant="primary" onClick={handleShare} />
+          </ButtonRow>
         </Stack>
       </Stack>
 

--- a/apps/aurora-portal/src/client/routes/gardener/-components/DeleteClusterDialog.tsx
+++ b/apps/aurora-portal/src/client/routes/gardener/-components/DeleteClusterDialog.tsx
@@ -32,7 +32,7 @@ export const DeleteClusterDialog: React.FC<DeleteClusterGardenerDialogProps> = (
         onClose()
       }}
       modalFooter={
-        <ModalFooter className="flex justify-end gap-3 px-8 mt-8">
+        <ModalFooter className="flex justify-end ">
           <ButtonRow>
             <Button
               variant="primary-danger"
@@ -49,30 +49,29 @@ export const DeleteClusterDialog: React.FC<DeleteClusterGardenerDialogProps> = (
           </ButtonRow>
         </ModalFooter>
       }
-      children={
-        <div className="px-8 space-y-6">
-          {/* Warning */}
-          <Message dismissible={false} variant="warning">
-            <Trans>This action cannot be undone. The cluster will be permanently deleted.</Trans>
-          </Message>
+    >
+      <div>
+        {/* Warning */}
+        <Message dismissible={false} variant="warning">
+          <Trans>This action cannot be undone. The cluster will be permanently deleted.</Trans>
+        </Message>
 
-          {/* Question */}
-          <p className="text-base text-left">
-            <Trans>
-              Would you like to remove the <strong className="text-theme-high font-semibold">{clusterName}</strong> from
-              your project?
-            </Trans>
-          </p>
+        {/* Question */}
+        <p className="mt-4">
+          <Trans>
+            Would you like to remove the <strong className="text-theme-high font-semibold">{clusterName}</strong> from
+            your project?
+          </Trans>
+        </p>
 
-          {/* Consequence */}
-          <p className="text-base text-left">
-            <Trans>
-              After continuing, your project will no longer have access to the{" "}
-              <strong className="text-theme-high font-semibold">{clusterName}</strong> resources.
-            </Trans>
-          </p>
-        </div>
-      }
-    ></Modal>
+        {/* Consequence */}
+        <p>
+          <Trans>
+            After continuing, your project will no longer have access to the{" "}
+            <strong className="text-theme-high font-semibold">{clusterName}</strong> resources.
+          </Trans>
+        </p>
+      </div>
+    </Modal>
   )
 }

--- a/apps/aurora-portal/src/client/routes/gardener/clusters/index.tsx
+++ b/apps/aurora-portal/src/client/routes/gardener/clusters/index.tsx
@@ -1,13 +1,11 @@
 import { createFileRoute, useLoaderData, useRouter } from "@tanstack/react-router"
 import { Plus, RefreshCw } from "lucide-react"
-import { toast } from "sonner"
 import React, { useState } from "react"
 import { Button } from "@cloudoperators/juno-ui-components/index"
 import { Cluster } from "@/server/Gardener/types/cluster"
 
 import { ClusterTable } from "../-components/ClusterTable"
 import CreateClusterWizard from "../-components/CreateClusterDialog"
-import { DeleteClusterDialog } from "../-components/DeleteClusterDialog"
 
 import { Filters } from "../-components/Filters"
 import { FilterSettings } from "../-components/Filters/types"
@@ -30,9 +28,6 @@ function RouteComponent() {
   const [filterSettings, setFilterSettings] = useState<FilterSettings>({})
 
   const [createWizardModal, setCreateWizardModal] = useState(false)
-
-  const [deleteClusterModal, setDeleteClusterModal] = useState(false)
-  const [deletedClusterName, setDeleteClusterName] = useState<string | null>(null)
 
   const handleRefresh = () => {
     router.invalidate()
@@ -71,8 +66,8 @@ function RouteComponent() {
   }
 
   // Get unique providers, regions and statuses from clusters
-  const versions = [...new Set(clusters?.map((cluster) => cluster.version) || [])]
-  const statuses = [...new Set(clusters?.map((cluster) => cluster.status) || [])]
+  const versions = [...new Set(clusters?.map((cluster: Cluster) => cluster.version) || [])]
+  const statuses = [...new Set(clusters?.map((cluster: Cluster) => cluster.status) || [])]
 
   // Filter clusters based on search and filter criteria
   // Update your filtered and sorted clusters
@@ -85,22 +80,6 @@ function RouteComponent() {
 
   const handleCreateWizzard = () => {
     setCreateWizardModal(true)
-  }
-
-  const handleDeleteCluster = async () => {
-    try {
-      await trpcClient?.gardener.deleteCluster.mutate({
-        name: deletedClusterName!,
-      })
-      toast.success("Cluster deleted successfully")
-      setDeleteClusterModal(false)
-      handleRefresh()
-    } catch (error) {
-      toast.error("Failed to delete cluster: " + (error instanceof Error ? error.message : "Unknown error"))
-    } finally {
-      setDeleteClusterModal(false)
-      handleRefresh()
-    }
   }
 
   return (
@@ -153,18 +132,6 @@ function RouteComponent() {
           isOpen={createWizardModal}
           onClose={() => {
             setCreateWizardModal(false)
-            handleRefresh()
-          }}
-        />
-      )}
-      {deleteClusterModal && (
-        <DeleteClusterDialog
-          clusterName={deletedClusterName!}
-          isOpen={deleteClusterModal}
-          onDelete={handleDeleteCluster}
-          onClose={() => {
-            setDeleteClusterModal(false)
-            setDeleteClusterName(null)
             handleRefresh()
           }}
         />


### PR DESCRIPTION
# Summary

The button allows users to delete a cluster.
Upon successful deletion (HTTP status code 200), the user is be navigated back to the cluster list.
#323 

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
