### PR TITLE
fix(ci): use correct actions for setup-node and cache steps

### DIFF
--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -17,18 +17,16 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
       with:
         node-version: ${{ inputs.node-version }}
-
     - name: Setup pnpm
       uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       with:
         version: ${{ inputs.pnpm-version }}
-
     - name: Cache pnpm store and node_modules
       id: cache-pnpm
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
       with:
         path: |
           ~/.local/share/pnpm/store
@@ -36,11 +34,9 @@ runs:
         key: ${{ runner.OS }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.OS }}-pnpm-
-
     - name: Install Dependencies
       run: pnpm install --frozen-lockfile
       shell: bash
-
     - name: Output Cache Hit Status
       run: echo "cache-hit=${{ steps.cache-pnpm.outputs.cache-hit }}" >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
Fix incorrect GitHub Actions usage in PNPM setup composite action

## Problem
The composite action was using `actions/checkout` for both Node.js setup and caching steps, causing validation errors due to incompatible input parameters.

## Solution
- Replace `actions/checkout` with `actions/setup-node` for Node.js installation
- Replace `actions/checkout` with `actions/cache` for dependency caching
- Update to pinned SHA versions for security

## Changes
- ✅ Node.js setup now works correctly
- ✅ PNPM cache functionality restored
- ✅ All input parameters properly recognized
# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
