### PR TITLE
chore(ci): fix setup-pnpm custom action configuration

### DIFF
--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -17,7 +17,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
       with:
         node-version: ${{ inputs.node-version }}
 
@@ -28,14 +28,14 @@ runs:
 
     - name: Cache pnpm store and node_modules
       id: cache-pnpm
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
       with:
         path: |
           ~/.local/share/pnpm/store
           node_modules
-        key: ${{ runner.OS }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.OS }}-pnpm-
+          ${{ runner.os }}-pnpm-
 
     - name: Install Dependencies
       run: pnpm install --frozen-lockfile


### PR DESCRIPTION
# 🐛 Problem

The semantic release workflow was failing with "Unexpected input(s)" errors when using the custom `./.github/actions/setup-pnpm` action. The errors indicated that invalid parameters were being passed to `actions/checkout`.

**Error messages:**
```bash
Unexpected input(s) 'node-version', valid inputs are ['repository', 'ref', 'token', ...]
Unexpected input(s) 'key', 'restore-keys', valid inputs are ['repository', 'ref', 'token', ...]
```

# 🔧 Solution
Fixed the `setup-pnpm/action.yaml` file by correcting the GitHub Actions being used:

## Changes Made:

1. **Node.js Setup:** Changed from `actions/checkout` to `actions/setup-node@v4.0.4` for setting up Node.js
2. **Caching:** Changed from `actions/checkout` to `actions/cache@v4.1.2` for dependency caching
3. **Environment Variable:** Fixed `runner.OS` to `runner.os` (proper lowercase format)

## Before:

```yaml
name: Setup Node.js
  uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
  with:
    node-version: ${{ inputs.node-version }}

- name: Cache pnpm store and node_modules
  uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
  with:
    path: |
      ~/.local/share/pnpm/store
      node_modules
    key: ${{ runner.OS }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
```

## After:
```yaml
 name: Setup Node.js
  uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
  with:
    node-version: ${{ inputs.node-version }}

- name: Cache pnpm store and node_modules
  uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
  with:
    path: |
      ~/.local/share/pnpm/store
      node_modules
    key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
 ```
 
# ✅ Testing

- [ ] Semantic release workflow should now run without "Unexpected input(s)" errors
- [ ] Node.js and PNPM setup should work correctly
- [ ] Dependency caching should function as expected

# 🔗 Related Issues
Fixes the semantic release workflow failures caused by incorrect GitHub Actions usage in the custom setup-pnpm action.


# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
