### PR TITLE
chore(bff): add function for bulk permission checks in compute

### DIFF
--- a/apps/aurora-portal/src/server/Compute/routers/permissionRouter.test.ts
+++ b/apps/aurora-portal/src/server/Compute/routers/permissionRouter.test.ts
@@ -311,4 +311,294 @@ describe("permissionRouter", () => {
       })
     })
   })
+
+  describe("Bulk permissions", () => {
+    describe("Array input validation", () => {
+      it("should accept array of valid permission strings", async () => {
+        const permissions = ["servers:list", "servers:create", "flavors:create"]
+        const result = await caller.canUserBulk(permissions)
+
+        expect(Array.isArray(result)).toBe(true)
+        expect(result).toHaveLength(3)
+        result.forEach((item) => expect(typeof item).toBe("boolean"))
+      })
+
+      it("should return empty array for empty input array", async () => {
+        const result = await caller.canUserBulk([])
+
+        expect(Array.isArray(result)).toBe(true)
+        expect(result).toHaveLength(0)
+      })
+
+      it("should throw BAD_REQUEST for array containing invalid permissions", async () => {
+        const permissions = ["servers:list", "invalid:permission", "flavors:create"]
+
+        await expect(caller.canUserBulk(permissions)).rejects.toThrow(
+          new TRPCError({ code: "BAD_REQUEST", message: "Unknown permission: invalid:permission" })
+        )
+      })
+
+      it("should throw BAD_REQUEST for array containing empty strings", async () => {
+        const permissions = ["servers:list", "", "flavors:create"]
+
+        await expect(caller.canUserBulk(permissions)).rejects.toThrow(
+          new TRPCError({ code: "BAD_REQUEST", message: "Unknown permission: " })
+        )
+      })
+
+      it("should throw BAD_REQUEST for array containing malformed permissions", async () => {
+        const permissions = ["servers:list", "just-a-string", "flavors:create"]
+
+        await expect(caller.canUserBulk(permissions)).rejects.toThrow(
+          new TRPCError({ code: "BAD_REQUEST", message: "Unknown permission: just-a-string" })
+        )
+      })
+    })
+
+    describe("Authentication validation with arrays", () => {
+      it("should throw UNAUTHORIZED for array input when no OpenStack session exists", async () => {
+        const mockContextWithoutOpenStack = {
+          ...mockContext,
+          openstack: null,
+        } as unknown as AuroraPortalContext
+        const callerWithoutOpenStack = createCaller(mockContextWithoutOpenStack)
+
+        await expect(callerWithoutOpenStack.canUserBulk(["servers:list", "flavors:create"])).rejects.toThrow(
+          new TRPCError({ code: "UNAUTHORIZED", message: "No valid OpenStack token found" })
+        )
+      })
+
+      it("should throw UNAUTHORIZED for array input when getToken returns null", async () => {
+        const mockOpenstackSessionWithNullToken = {
+          getToken: vi.fn(() => null),
+        }
+        const mockContextWithNullToken = {
+          ...mockContext,
+          openstack: mockOpenstackSessionWithNullToken,
+        } as unknown as AuroraPortalContext
+        const callerWithNullToken = createCaller(mockContextWithNullToken)
+
+        await expect(callerWithNullToken.canUserBulk(["servers:list", "flavors:create"])).rejects.toThrow(
+          new TRPCError({ code: "UNAUTHORIZED", message: "No valid OpenStack token found" })
+        )
+      })
+    })
+
+    describe("Bulk permission result consistency", () => {
+      it("should return same results for bulk check as individual checks", async () => {
+        const permissions = ["servers:list", "servers:create", "flavors:create", "images:list"]
+
+        // Get bulk results
+        const bulkResults = await caller.canUserBulk(permissions)
+
+        // Get individual results
+        const individualResults = await Promise.all(permissions.map((permission) => caller.canUser(permission)))
+
+        expect(bulkResults).toEqual(individualResults)
+      })
+
+      it("should maintain order of permissions in results", async () => {
+        const permissions = ["images:create", "servers:list", "flavors:delete", "servers:create"]
+
+        const result = await caller.canUserBulk(permissions)
+
+        expect(Array.isArray(result)).toBe(true)
+        expect(result).toHaveLength(4)
+
+        // Verify each position corresponds to the correct permission by checking individual results
+        for (let i = 0; i < permissions.length; i++) {
+          const individualResult = await caller.canUser(permissions[i])
+          expect(result[i]).toBe(individualResult)
+        }
+      })
+
+      it("should handle duplicate permissions in array", async () => {
+        const permissions = ["servers:list", "flavors:create", "servers:list", "images:list", "servers:list"]
+
+        const result = await caller.canUserBulk(permissions)
+
+        expect(Array.isArray(result)).toBe(true)
+        expect(result).toHaveLength(5)
+
+        // All servers:list results should be the same
+        const serversListResult = await caller.canUser("servers:list")
+        expect(result[0]).toBe(serversListResult) // First servers:list
+        expect(result[2]).toBe(serversListResult) // Second servers:list
+        expect(result[4]).toBe(serversListResult) // Third servers:list
+      })
+    })
+
+    describe("Large bulk operations", () => {
+      it("should handle large arrays of permissions", async () => {
+        const allPermissions = [
+          "servers:list",
+          "servers:create",
+          "servers:delete",
+          "servers:update",
+          "flavors:create",
+          "flavors:delete",
+          "flavors:update",
+          "flavors:list_projects",
+          "flavors:add_project",
+          "flavors:remove_project",
+          "flavor_specs:list",
+          "flavor_specs:create",
+          "flavor_specs:update",
+          "flavor_specs:delete",
+          "images:list",
+          "images:create",
+          "images:delete",
+          "images:update",
+        ]
+
+        const result = await caller.canUserBulk(allPermissions)
+
+        expect(Array.isArray(result)).toBe(true)
+        expect(result).toHaveLength(allPermissions.length)
+        result.forEach((item) => expect(typeof item).toBe("boolean"))
+      })
+
+      it("should handle mixed permission types efficiently", async () => {
+        const mixedPermissions = [
+          "servers:list",
+          "flavors:create",
+          "images:delete",
+          "flavor_specs:update",
+          "servers:create",
+          "images:list",
+          "flavors:delete",
+          "flavor_specs:list",
+        ]
+
+        const startTime = Date.now()
+        const result = await caller.canUserBulk(mixedPermissions)
+        const endTime = Date.now()
+
+        expect(Array.isArray(result)).toBe(true)
+        expect(result).toHaveLength(mixedPermissions.length)
+        result.forEach((item) => expect(typeof item).toBe("boolean"))
+
+        // Should complete in reasonable time (adjust threshold as needed)
+        expect(endTime - startTime).toBeLessThan(1000)
+      })
+    })
+
+    describe("Error handling in bulk operations", () => {
+      it("should stop processing and throw error on first invalid permission", async () => {
+        const permissions = ["servers:list", "flavors:create", "invalid:permission", "images:list"]
+
+        await expect(caller.canUserBulk(permissions)).rejects.toThrow(
+          new TRPCError({ code: "BAD_REQUEST", message: "Unknown permission: invalid:permission" })
+        )
+      })
+
+      it("should handle getToken errors during bulk operations", async () => {
+        const mockOpenstackSessionWithError = {
+          getToken: vi.fn(() => {
+            throw new Error("Token retrieval failed")
+          }),
+        }
+        const mockContextWithError = {
+          ...mockContext,
+          openstack: mockOpenstackSessionWithError,
+        } as unknown as AuroraPortalContext
+        const callerWithError = createCaller(mockContextWithError)
+
+        await expect(callerWithError.canUserBulk(["servers:list", "flavors:create"])).rejects.toThrow(
+          "Token retrieval failed"
+        )
+      })
+    })
+
+    describe("Context data handling with bulk operations", () => {
+      it("should handle missing project data for bulk permissions", async () => {
+        const mockOpenstackSessionWithoutProject = {
+          getToken: vi.fn(() => ({
+            tokenData: {
+              project: undefined,
+              user: { id: "test-user-id", name: "test-user", domain: { id: "default", name: "Default" } },
+              roles: [{ name: "member", id: "member-role-id" }],
+            },
+            authToken: "test-auth-token",
+          })),
+        }
+        const mockContextWithoutProject = {
+          ...mockContext,
+          openstack: mockOpenstackSessionWithoutProject,
+        } as unknown as AuroraPortalContext
+        const callerWithoutProject = createCaller(mockContextWithoutProject)
+
+        const permissions = ["servers:list", "flavors:create", "images:list"]
+        const result = await callerWithoutProject.canUserBulk(permissions)
+
+        expect(Array.isArray(result)).toBe(true)
+        expect(result).toHaveLength(3)
+        result.forEach((item) => expect(typeof item).toBe("boolean"))
+      })
+
+      it("should handle different user roles for bulk permissions", async () => {
+        const permissions = ["servers:list", "servers:create", "flavors:create"]
+        const rolesTestCases = [
+          [{ name: "admin", id: "admin-id" }],
+          [{ name: "member", id: "member-id" }],
+          [{ name: "reader", id: "reader-id" }],
+        ]
+
+        for (const roles of rolesTestCases) {
+          const mockOpenstackSessionWithRoles = {
+            getToken: vi.fn(() => ({
+              tokenData: {
+                project: { id: "test-project-id", name: "Test Project", domain: { id: "default", name: "Default" } },
+                user: { id: "test-user-id", name: "test-user", domain: { id: "default", name: "Default" } },
+                roles,
+              },
+              authToken: "test-auth-token",
+            })),
+          }
+          const mockContextWithRoles = {
+            ...mockContext,
+            openstack: mockOpenstackSessionWithRoles,
+          } as unknown as AuroraPortalContext
+          const callerWithRoles = createCaller(mockContextWithRoles)
+
+          const result = await callerWithRoles.canUserBulk(permissions)
+          expect(Array.isArray(result)).toBe(true)
+          expect(result).toHaveLength(3)
+          result.forEach((item) => expect(typeof item).toBe("boolean"))
+        }
+      })
+    })
+
+    describe("Performance and concurrency with bulk operations", () => {
+      it("should handle concurrent bulk permission checks", async () => {
+        const permissionSets = [
+          ["servers:list", "servers:create"],
+          ["flavors:create", "flavors:delete"],
+          ["images:list", "images:create", "images:update"],
+        ]
+
+        const promises = permissionSets.map((permissions) => caller.canUserBulk(permissions))
+        const results = await Promise.all(promises)
+
+        expect(results).toHaveLength(3)
+        expect(results[0]).toHaveLength(2)
+        expect(results[1]).toHaveLength(2)
+        expect(results[2]).toHaveLength(3)
+
+        results.forEach((resultArray) => {
+          expect(Array.isArray(resultArray)).toBe(true)
+          resultArray.forEach((item) => expect(typeof item).toBe("boolean"))
+        })
+      })
+
+      it("should maintain consistency between sequential bulk calls", async () => {
+        const permissions = ["servers:list", "flavors:create", "images:list"]
+
+        const result1 = await caller.canUserBulk(permissions)
+        const result2 = await caller.canUserBulk(permissions)
+
+        expect(result1).toEqual(result2)
+      })
+    })
+  })
 })


### PR DESCRIPTION
This PR adds a new function to compute permission router to allow to request multiple permissions in one call. 

```ts
canUserBulk(permissions: string[]): boolean[]
```
 
# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
