### PR TITLE
fix(portal): allow null image size

### DIFF
--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/-components/Images/-components/SizeDisplay.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/-components/Images/-components/SizeDisplay.tsx
@@ -1,5 +1,5 @@
-function formatBytes(bytes: number, decimals = 2) {
-  if (bytes === 0) return "0 Bytes"
+function formatBytes(bytes: number | null, decimals = 2) {
+  if (bytes === 0 || !bytes) return "0 Bytes"
 
   const k = 1024
   const dm = decimals < 0 ? 0 : decimals
@@ -11,7 +11,7 @@ function formatBytes(bytes: number, decimals = 2) {
 }
 
 interface SizeDisplayProps {
-  size: number | undefined
+  size: number | null | undefined
 }
 
 export function SizeDisplay({ size }: SizeDisplayProps) {

--- a/apps/aurora-portal/src/server/Compute/types/image.ts
+++ b/apps/aurora-portal/src/server/Compute/types/image.ts
@@ -77,7 +77,7 @@ export const imageSchema = z
     disk_format: diskFormatSchema.optional().nullable(),
     min_ram: z.number().optional(),
     min_disk: z.number().optional(),
-    size: z.number().optional(),
+    size: z.number().optional().nullable(),
     virtual_size: z.number().optional().nullable(),
     created_at: z.string().optional(),
     updated_at: z.string().optional(),


### PR DESCRIPTION
# Summary

allow null image size
Closes [#448](https://github.com/cobaltcore-dev/aurora-dashboard/issues/448)