### PR TITLE
fix(portal): fix input artifact of two rowed label

### DIFF
--- a/apps/aurora-portal/src/client/components/ListToolbar/index.tsx
+++ b/apps/aurora-portal/src/client/components/ListToolbar/index.tsx
@@ -133,12 +133,19 @@ export const ListToolbar = ({
         </Stack>
       )}
 
-      <div className="flex w-full flex-col flex-wrap items-center gap-4 md:flex-row">
-        {filtersProps && <FiltersInput {...filtersProps} />}
-        {sortProps && <SortInput {...sortProps} />}
-
+      <div className="flex w-full flex-col items-stretch gap-4 md:flex-row md:items-center">
+        {filtersProps && (
+          <div className="w-full md:w-auto md:min-w-[150px]">
+            <FiltersInput {...filtersProps} />
+          </div>
+        )}
+        {sortProps && (
+          <div className="w-full md:w-auto md:min-w-[180px]">
+            <SortInput {...sortProps} />
+          </div>
+        )}
         {searchProps && (
-          <div className="w-full md:ml-auto md:w-auto">
+          <div className="w-full md:ml-auto md:w-auto md:min-w-[100px]">
             <SearchInput {...searchProps} />
           </div>
         )}


### PR DESCRIPTION
# Summary

Fixed Select component label overflow issue in ListToolbar when the "Sort by" label is longer than the selected value.

# Changes Made

- Wrapped `FiltersInput`, `SortInput`, and `SearchInput` in individual containers with responsive width constraints
- Added `w-full md:w-auto md:min-w-[200px]` pattern to ensure components stack vertically on small displays

# Related Issues
Closes #536

# Screenshot 
Old:
<img width="403" height="96" alt="Bildschirmfoto 2026-02-27 um 22 15 05" src="https://github.com/user-attachments/assets/536abc49-b1a4-4003-9ae9-1de67cf3b5af" />
new:
<img width="251" height="101" alt="Bildschirmfoto 2026-02-27 um 22 17 52" src="https://github.com/user-attachments/assets/e640ce15-41bc-4ec6-9c15-72f9ed790dd0" />


# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
