### PR TITLE
fix(portal): isolate React Query cache per project using queryKeyHashFn

### DIFF
--- a/apps/aurora-portal/src/client/App.tsx
+++ b/apps/aurora-portal/src/client/App.tsx
@@ -2,7 +2,7 @@ import { AppShellProvider } from "@cloudoperators/juno-ui-components"
 import { router } from "./router"
 import { RouterProvider } from "@tanstack/react-router"
 import { AuthProvider, useAuth } from "./store/AuthProvider"
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { QueryClient, QueryClientProvider, hashKey } from "@tanstack/react-query"
 import { trpcReact, trpcClient, trpcReactClient } from "./trpcClient"
 import { InactivityModal } from "./components/Auth/InactivityModal"
 import { useState, useMemo, useRef } from "react"
@@ -20,6 +20,16 @@ const navItems: NavigationItem[] = [{ route: "/about", label: "About" }]
 
 const currentTheme = (localStorage.getItem("aurora-theme") || "theme-light") as "theme-dark" | "theme-light"
 
+/**
+ * Reads the active projectId from the router state at the time the query key is hashed.
+ * This ensures each project gets its own isolated cache entries without requiring
+ * any global mutable state or changes to individual query hooks.
+ */
+const getActiveProjectId = (): string => {
+  const match = router.state.matches.findLast((m) => "projectId" in (m.params ?? {}))
+  return (match?.params as { projectId?: string })?.projectId ?? ""
+}
+
 const App = (props: AppProps) => {
   const [queryClient] = useState(
     () =>
@@ -28,6 +38,9 @@ const App = (props: AppProps) => {
           queries: {
             staleTime: 60 * 1000,
             refetchOnWindowFocus: false,
+            // Prepend the active projectId to every query hash so that
+            // switching projects never returns cached data from a previous project.
+            queryKeyHashFn: (queryKey) => hashKey([getActiveProjectId(), ...queryKey]),
           },
         },
       })


### PR DESCRIPTION
## Problem

When switching between projects, React Query returned cached data from the
previous project. The BFF session scope is updated via `setCurrentScope` in
the `$projectId` loader, but the global `staleTime: 60s` prevented
refetching — so users saw stale data scoped to a different project.

## Solution

Override `queryKeyHashFn` on the global `QueryClient` to prepend the active
`projectId` to every query hash, derived directly from `router.state.matches`
at hash time.
```ts
const getActiveProjectId = (): string => {
  const match = router.state.matches.findLast((m) => "projectId" in (m.params ?? {}))
  return (match?.params as { projectId?: string })?.projectId ?? ""
}

queryKeyHashFn: (queryKey) => hashKey([getActiveProjectId(), ...queryKey])
```

## Expected Behavior After Fix

- Each project gets fully isolated cache entries automatically
- Switching projects never serves data from a previous project's cache
- No changes required in individual query hooks or BFF routers
- No `invalidateQueries` calls needed on project switch

## Changes

- `App.tsx` — added `getActiveProjectId()` helper and `queryKeyHashFn` to
  `QueryClient` default options

## Notes

Cache entries accumulate per project over a session. This is acceptable
given the 60s `staleTime`, but `queryClient.removeQueries` can be called
in the `$projectId` loader if memory becomes a concern.

## Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
