### PR TITLE
feat(deps): add pnpm audit job and audit script for CVE scanning

### DIFF
--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -132,3 +132,17 @@ jobs:
           pnpm-version: ${{ env.PNPM_VERSION }}
       - name: Run Build
         run: pnpm i && pnpm build
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup PNPM
+        uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+
+      - name: Run Audit
+        run: pnpm audit --prod

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -134,6 +134,7 @@ jobs:
         run: pnpm i && pnpm build
 
   audit:
+    needs: install-deps
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -145,4 +146,4 @@ jobs:
           pnpm-version: ${{ env.PNPM_VERSION }}
 
       - name: Run Audit
-        run: pnpm audit --prod
+        run: pnpm run audit

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "generate:package": "turbo gen workspace --type package --copy @cobalcore-dev/aurora-package-template --name",
     "prepare": "husky",
     "release": "semantic-release",
-    "release:dry": "semantic-release --dry-run"
+    "release:dry": "semantic-release --dry-run",
+    "audit": "pnpm audit --prod"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.3.1",


### PR DESCRIPTION
Adds an audit CI job that runs pnpm audit --prod on every build, and a corresponding audit npm script for local use.

Closes #640 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated automated production dependency vulnerability scanning into the CI/CD pipeline for continuous security monitoring
  * Added an audit command to locally check for dependencies with known vulnerabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->