### PR TITLE
chore(deps): group minor and patch renovate updates into single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch"
+    }
   ]
 }


### PR DESCRIPTION
  ## Summary                                     
  - Configures Renovate to group all minor and   
  patch dependency updates into a single PR   
  - Major version updates continue to be opened  
  as individual PRs                            
                                                 
  ## Why          
  Renovate was creating a large number of        
  individual PRs for minor/patch updates, causing
   noise. This change reduces that to a single   
  grouped PR while keeping major updates separate
   for easier review.   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to improve how dependency updates are organized and grouped in pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->