### PR TITLE
fix(portal): restore missing setPageTitle calls in route components

### DIFF
--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/flavors/index.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/flavors/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { useLingui } from "@lingui/react/macro"
 import { Flavors } from "../-components/Flavors/List"
 import type { RouteInfo } from "@/client/routes/routeInfo"
 
@@ -8,7 +9,9 @@ export const Route = createFileRoute("/_auth/accounts/$accountId/projects/$proje
 })
 
 function RouteComponent() {
+  const { t } = useLingui()
   const { projectId } = Route.useParams()
-  const { trpcClient } = Route.useRouteContext()
+  const { trpcClient, setPageTitle } = Route.useRouteContext()
+  setPageTitle(t`Flavors`)
   return <Flavors project={projectId} client={trpcClient!} />
 }

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/images/index.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/images/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { useLingui } from "@lingui/react/macro"
 import { Images } from "../-components/Images/List"
 import type { RouteInfo } from "@/client/routes/routeInfo"
 
@@ -8,6 +9,8 @@ export const Route = createFileRoute("/_auth/accounts/$accountId/projects/$proje
 })
 
 function RouteComponent() {
-  const { trpcClient } = Route.useRouteContext()
+  const { t } = useLingui()
+  const { trpcClient, setPageTitle } = Route.useRouteContext()
+  setPageTitle(t`Images`)
   return <Images client={trpcClient!} />
 }

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/instances.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/instances.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
+import { useLingui } from "@lingui/react/macro"
 import { getServiceIndex } from "@/server/Authentication/helpers"
 import { Instances } from "./-components/Instances/List"
 import type { RouteInfo } from "@/client/routes/routeInfo"
@@ -22,7 +23,9 @@ export const Route = createFileRoute("/_auth/accounts/$accountId/projects/$proje
 })
 
 function RouteComponent() {
+  const { t } = useLingui()
   const { projectId } = Route.useParams()
-  const { trpcClient } = Route.useRouteContext()
+  const { trpcClient, setPageTitle } = Route.useRouteContext()
+  setPageTitle(t`Instances`)
   return <Instances client={trpcClient!} project={projectId} viewMode="list" />
 }

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/keypairs.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/keypairs.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
+import { useLingui } from "@lingui/react/macro"
 import { getServiceIndex } from "@/server/Authentication/helpers"
 import { KeyPairs } from "./-components/KeyPairs/List"
 import type { RouteInfo } from "@/client/routes/routeInfo"
@@ -22,7 +23,9 @@ export const Route = createFileRoute("/_auth/accounts/$accountId/projects/$proje
 })
 
 function RouteComponent() {
+  const { t } = useLingui()
   const { projectId } = Route.useParams()
-  const { trpcClient } = Route.useRouteContext()
+  const { trpcClient, setPageTitle } = Route.useRouteContext()
+  setPageTitle(t`Key Pairs`)
   return <KeyPairs project={projectId} client={trpcClient!} />
 }

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/overview.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/overview.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { useLingui } from "@lingui/react/macro"
 import { Overview } from "./-components/Overview"
 import type { RouteInfo } from "@/client/routes/routeInfo"
 
@@ -8,8 +9,9 @@ export const Route = createFileRoute("/_auth/accounts/$accountId/projects/$proje
 })
 
 function RouteComponent() {
+  const { t } = useLingui()
   const { projectId } = Route.useParams()
-  const { trpcClient } = Route.useRouteContext()
-
+  const { trpcClient, setPageTitle } = Route.useRouteContext()
+  setPageTitle(t`Compute Overview`)
   return <Overview project={projectId} client={trpcClient!} />
 }

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/servergroups.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/servergroups.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
+import { useLingui } from "@lingui/react/macro"
 import { getServiceIndex } from "@/server/Authentication/helpers"
 import { ServerGroups } from "./-components/ServerGroups/List"
 import type { RouteInfo } from "@/client/routes/routeInfo"
@@ -22,7 +23,9 @@ export const Route = createFileRoute("/_auth/accounts/$accountId/projects/$proje
 })
 
 function RouteComponent() {
+  const { t } = useLingui()
   const { projectId } = Route.useParams()
-  const { trpcClient } = Route.useRouteContext()
+  const { trpcClient, setPageTitle } = Route.useRouteContext()
+  setPageTitle(t`Server Groups`)
   return <ServerGroups project={projectId} client={trpcClient!} />
 }

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/network/floatingips/$floatingIpId.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/network/floatingips/$floatingIpId.tsx
@@ -18,6 +18,7 @@ function RouteComponent() {
   const { accountId, projectId, floatingIpId } = useParams({
     from: "/_auth/accounts/$accountId/projects/$projectId/network/floatingips/$floatingIpId",
   })
+  const { setPageTitle } = Route.useRouteContext()
 
   const navigateToProjectNetwork = () => {
     navigate({
@@ -43,6 +44,7 @@ function RouteComponent() {
   })
 
   if (isLoading) {
+    setPageTitle(t`Loading...`)
     return (
       <Stack className="fixed inset-0" distribution="center" alignment="center" direction="vertical">
         <Spinner variant="primary" size="large" className="mb-2" />
@@ -78,6 +80,7 @@ function RouteComponent() {
     )
   }
 
+  setPageTitle(floatingIp.floating_ip_address || floatingIpId)
   return (
     <Stack direction="vertical">
       <Breadcrumb className="my-6">

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/network/overview.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/network/overview.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { Trans } from "@lingui/react/macro"
+import { useLingui, Trans } from "@lingui/react/macro"
 import type { RouteInfo } from "@/client/routes/routeInfo"
 
 export const Route = createFileRoute("/_auth/accounts/$accountId/projects/$projectId/network/overview")({
@@ -8,6 +8,9 @@ export const Route = createFileRoute("/_auth/accounts/$accountId/projects/$proje
 })
 
 function RouteComponent() {
+  const { t } = useLingui()
+  const { setPageTitle } = Route.useRouteContext()
+  setPageTitle(t`Network Overview`)
   return (
     <div className="p-4 text-center">
       <Trans>Network Overview</Trans>

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/network/securitygroups/$securityGroupId/index.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/network/securitygroups/$securityGroupId/index.tsx
@@ -47,6 +47,7 @@ function RouteComponent() {
   })
   const navigate = useNavigate()
   const { t } = useLingui()
+  const { setPageTitle } = Route.useRouteContext()
 
   // Rules filtering using the same pattern as List page
   const {
@@ -142,6 +143,7 @@ function RouteComponent() {
 
   // Handle loading state
   if (isLoading) {
+    setPageTitle(t`Loading...`)
     return (
       <Stack className="fixed inset-0" distribution="center" alignment="center" direction="vertical">
         <Spinner variant="primary" size="large" className="mb-2" />
@@ -182,6 +184,7 @@ function RouteComponent() {
   }
 
   // Render success state
+  setPageTitle(securityGroup.name || securityGroup.id)
   return (
     <Stack direction="vertical">
       <Breadcrumb className="my-6">

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/network/securitygroups/index.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/network/securitygroups/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { useLingui } from "@lingui/react/macro"
 import { SecurityGroups } from "../-components/SecurityGroups/List"
 import type { RouteInfo } from "@/client/routes/routeInfo"
 
@@ -8,5 +9,8 @@ export const Route = createFileRoute("/_auth/accounts/$accountId/projects/$proje
 })
 
 function RouteComponent() {
+  const { t } = useLingui()
+  const { setPageTitle } = Route.useRouteContext()
+  setPageTitle(t`Security Groups`)
   return <SecurityGroups />
 }


### PR DESCRIPTION
## Summary
                                                    
  - The refactor in #699 (splat routes → explicit named routes) split route rendering into individual files but without `setPageTitle()` - this is now fixed
     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Page titles across compute and network management sections are now fully localized to match your language preferences.
  * Dynamic page titles that reflect current content state, including loading status and resource-specific information (e.g., resource names, IP addresses).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->