### PR TITLE
refactor(bff): make permission as single source instead of two

### DIFF
--- a/apps/aurora-portal/README.md
+++ b/apps/aurora-portal/README.md
@@ -34,12 +34,10 @@ The policy engine loader follows a simple override mechanism:
 
 ```typescript
 export const loadPolicyEngine = (fileName: string) => {
-  let file: string
-  if (fs.existsSync(path.join(__dirname, `./permission_custom_policies/${fileName}`))) {
-    file = path.join(__dirname, `./permission_custom_policies/${fileName}`)
-  } else {
-    file = path.join(__dirname, `./permission_policies/${fileName}`)
-  }
+  const customPath = path.join(__dirname, `../../permission_custom_policies/${fileName}`)
+  const defaultPath = path.join(__dirname, `../../permission_policies/${fileName}`)
+
+  const file = fs.existsSync(customPath) ? customPath : defaultPath
   return createPolicyEngineFromFile(file)
 }
 ```
@@ -47,7 +45,7 @@ export const loadPolicyEngine = (fileName: string) => {
 ### Directory Structure
 
 ```
-src/server/
+apps/aurora-portal/
 ├── permission_policies/          # Default policy files
 │   ├── compute.yaml              # Default compute permissions
 │   ├── network.yaml              # Default network permissions

--- a/apps/aurora-portal/README.md
+++ b/apps/aurora-portal/README.md
@@ -44,7 +44,7 @@ export const loadPolicyEngine = (fileName: string) => {
 
 ### Directory Structure
 
-```
+```text
 apps/aurora-portal/
 ├── permission_policies/          # Default policy files
 │   ├── compute.yaml              # Default compute permissions

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/-components/Flavors/-components/EditSpecModal.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/-components/Flavors/-components/EditSpecModal.tsx
@@ -26,10 +26,9 @@ interface EditSpecModalProps {
 }
 
 const createPermissionsPromise = (client: TrpcClient) => {
-  return Promise.all([
-    client.compute.canUser.query("flavor_specs:create"),
-    client.compute.canUser.query("flavor_specs:delete"),
-  ]).then(([canCreate, canDelete]) => ({ canCreate, canDelete }))
+  return client.compute.canUser
+    .query(["flavor_specs:create", "flavor_specs:delete"])
+    .then(([canCreate, canDelete]) => ({ canCreate, canDelete }))
 }
 
 const createExtraSpecsPromise = (client: TrpcClient, project: string, flavorId: string) => {

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/-components/Flavors/-components/ManageAccessModal.test.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/-components/Flavors/-components/ManageAccessModal.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, act, waitFor } from "@testing-library/react"
 import { describe, it, expect, beforeAll, vi, beforeEach } from "vitest"
-import { EditSpecModal } from "./EditSpecModal"
+import { ManageAccessModal } from "./ManageAccessModal"
 import { TrpcClient } from "@/client/trpcClient"
 import { I18nProvider } from "@lingui/react"
 import { ReactNode } from "react"
@@ -9,7 +9,7 @@ import { Flavor } from "@/server/Compute/types/flavor"
 
 const TestingProvider = ({ children }: { children: ReactNode }) => <I18nProvider i18n={i18n}>{children}</I18nProvider>
 
-describe("EditSpecModal", () => {
+describe("ManageAccessModal", () => {
   beforeAll(async () => {
     await act(async () => {
       i18n.activate("en")
@@ -21,24 +21,34 @@ describe("EditSpecModal", () => {
       canUser: {
         query: vi.fn().mockResolvedValue([true, true]),
       },
-      getExtraSpecs: {
-        query: vi.fn().mockResolvedValue({}),
+      getFlavorAccess: {
+        query: vi.fn().mockResolvedValue([]),
       },
-      createExtraSpecs: {
-        mutate: vi.fn().mockResolvedValue({ success: true }),
+      addTenantAccess: {
+        mutate: vi.fn().mockResolvedValue([]),
       },
-      deleteExtraSpec: {
-        mutate: vi.fn().mockResolvedValue({ success: true }),
+      removeTenantAccess: {
+        mutate: vi.fn().mockResolvedValue([]),
       },
     },
   } as unknown as TrpcClient
 
-  const mockFlavor: Flavor = {
+  const mockPrivateFlavor: Flavor = {
     id: "test-flavor-id",
     name: "Test Flavor",
     vcpus: 2,
     ram: 1024,
     disk: 10,
+    "os-flavor-access:is_public": false,
+  }
+
+  const mockPublicFlavor: Flavor = {
+    id: "test-public-flavor-id",
+    name: "Public Flavor",
+    vcpus: 4,
+    ram: 2048,
+    disk: 20,
+    "os-flavor-access:is_public": true,
   }
 
   const mockOnClose = vi.fn()
@@ -50,56 +60,56 @@ describe("EditSpecModal", () => {
   it("renders the modal when open", async () => {
     await act(async () => {
       render(
-        <EditSpecModal
+        <ManageAccessModal
           client={mockClient}
           isOpen={true}
           onClose={mockOnClose}
           project="test-project"
-          flavor={mockFlavor}
+          flavor={mockPrivateFlavor}
         />,
         { wrapper: TestingProvider }
       )
     })
 
-    expect(screen.getByText("Edit Metadata")).toBeInTheDocument()
+    expect(screen.getByText("Manage Access - Test Flavor")).toBeInTheDocument()
   })
 
   it("does not render when modal is closed", () => {
     render(
-      <EditSpecModal
+      <ManageAccessModal
         client={mockClient}
         isOpen={false}
         onClose={mockOnClose}
         project="test-project"
-        flavor={mockFlavor}
+        flavor={mockPrivateFlavor}
       />,
       { wrapper: TestingProvider }
     )
 
-    expect(screen.queryByText("Edit Metadata")).not.toBeInTheDocument()
+    expect(screen.queryByText("Manage Access - Test Flavor")).not.toBeInTheDocument()
   })
 
-  it("shows add button when user has create permissions", async () => {
+  it("shows add button when user has add permissions", async () => {
     await act(async () => {
       render(
-        <EditSpecModal
+        <ManageAccessModal
           client={mockClient}
           isOpen={true}
           onClose={mockOnClose}
           project="test-project"
-          flavor={mockFlavor}
+          flavor={mockPrivateFlavor}
         />,
         { wrapper: TestingProvider }
       )
     })
 
     await waitFor(() => {
-      const addSpecButton = screen.getByRole("button", { name: /Add Metadata/i })
-      expect(addSpecButton).toBeInTheDocument()
+      const addTenantButton = screen.getByRole("button", { name: /Add Tenant Access/i })
+      expect(addTenantButton).toBeInTheDocument()
     })
   })
 
-  it("hides add button when user lacks create permissions", async () => {
+  it("hides add button when user lacks add permissions", async () => {
     const mockClientNoPermission = {
       ...mockClient,
       compute: {
@@ -112,104 +122,132 @@ describe("EditSpecModal", () => {
 
     await act(async () => {
       render(
-        <EditSpecModal
+        <ManageAccessModal
           client={mockClientNoPermission}
           isOpen={true}
           onClose={mockOnClose}
           project="test-project"
-          flavor={mockFlavor}
+          flavor={mockPrivateFlavor}
         />,
         { wrapper: TestingProvider }
       )
     })
 
     await waitFor(() => {
-      expect(screen.queryByText("Add Metadata")).not.toBeInTheDocument()
+      expect(screen.queryByText("Add Tenant Access")).not.toBeInTheDocument()
     })
   })
 
-  it("displays existing extra specs", async () => {
-    const mockClientWithSpecs = {
+  it("displays existing tenant access rows", async () => {
+    const mockClientWithAccess = {
       ...mockClient,
       compute: {
         ...mockClient.compute,
-        getExtraSpecs: {
-          query: vi.fn().mockResolvedValue({
-            "hw:cpu_policy": "dedicated",
-            "hw:mem_page_size": "large",
-          }),
+        getFlavorAccess: {
+          query: vi.fn().mockResolvedValue([
+            { flavor_id: "test-flavor-id", tenant_id: "tenant-a" },
+            { flavor_id: "test-flavor-id", tenant_id: "tenant-b" },
+          ]),
         },
       },
     } as unknown as TrpcClient
 
     await act(async () => {
       render(
-        <EditSpecModal
-          client={mockClientWithSpecs}
+        <ManageAccessModal
+          client={mockClientWithAccess}
           isOpen={true}
           onClose={mockOnClose}
           project="test-project"
-          flavor={mockFlavor}
+          flavor={mockPrivateFlavor}
         />,
         { wrapper: TestingProvider }
       )
     })
 
     await waitFor(() => {
-      expect(screen.getByText("hw:cpu_policy")).toBeInTheDocument()
-      expect(screen.getByText("dedicated")).toBeInTheDocument()
-      expect(screen.getByText("hw:mem_page_size")).toBeInTheDocument()
-      expect(screen.getByText("large")).toBeInTheDocument()
+      expect(screen.getByText("tenant-a")).toBeInTheDocument()
+      expect(screen.getByText("tenant-b")).toBeInTheDocument()
     })
   })
 
-  it("shows empty state when no specs exist", async () => {
+  it("shows empty state when no access exists for private flavor", async () => {
     await act(async () => {
       render(
-        <EditSpecModal
+        <ManageAccessModal
           client={mockClient}
           isOpen={true}
           onClose={mockOnClose}
           project="test-project"
-          flavor={mockFlavor}
+          flavor={mockPrivateFlavor}
         />,
         { wrapper: TestingProvider }
       )
     })
 
     await waitFor(() => {
-      expect(screen.getByText('No extra specs found. Click "Add Metadata" to create one.')).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          'No specific tenant access configured for this private flavor. Click "Add Tenant Access" to grant access.'
+        )
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("shows public flavor information message", async () => {
+    await act(async () => {
+      render(
+        <ManageAccessModal
+          client={mockClient}
+          isOpen={true}
+          onClose={mockOnClose}
+          project="test-project"
+          flavor={mockPublicFlavor}
+        />,
+        { wrapper: TestingProvider }
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("This is a public flavor. All tenants have access to it.")).toBeInTheDocument()
+      expect(screen.queryByText("Add Tenant Access")).not.toBeInTheDocument()
     })
   })
 
   it("handles null flavor with not rendering", async () => {
     await act(async () => {
       render(
-        <EditSpecModal client={mockClient} isOpen={true} onClose={mockOnClose} project="test-project" flavor={null} />,
-        { wrapper: TestingProvider }
-      )
-    })
-
-    expect(screen.queryByText("Edit Metadata")).not.toBeInTheDocument()
-    expect(screen.queryByText("Add Metadata")).not.toBeInTheDocument()
-  })
-
-  it("fetches extra specs with correct parameters", async () => {
-    await act(async () => {
-      render(
-        <EditSpecModal
+        <ManageAccessModal
           client={mockClient}
           isOpen={true}
           onClose={mockOnClose}
           project="test-project"
-          flavor={mockFlavor}
+          flavor={null}
+        />,
+        { wrapper: TestingProvider }
+      )
+    })
+
+    expect(screen.queryByText("Manage Access - Test Flavor")).not.toBeInTheDocument()
+    expect(screen.queryByText("Add Tenant Access")).not.toBeInTheDocument()
+  })
+
+  it("fetches flavor access with correct parameters", async () => {
+    await act(async () => {
+      render(
+        <ManageAccessModal
+          client={mockClient}
+          isOpen={true}
+          onClose={mockOnClose}
+          project="test-project"
+          flavor={mockPrivateFlavor}
         />,
         { wrapper: TestingProvider }
       )
     })
 
     await waitFor(() => {
-      expect(mockClient.compute.getExtraSpecs.query).toHaveBeenCalledWith({
+      expect(mockClient.compute.getFlavorAccess.query).toHaveBeenCalledWith({
         projectId: "test-project",
         flavorId: "test-flavor-id",
       })
@@ -219,19 +257,19 @@ describe("EditSpecModal", () => {
   it("checks user permissions on mount", async () => {
     await act(async () => {
       render(
-        <EditSpecModal
+        <ManageAccessModal
           client={mockClient}
           isOpen={true}
           onClose={mockOnClose}
           project="test-project"
-          flavor={mockFlavor}
+          flavor={mockPrivateFlavor}
         />,
         { wrapper: TestingProvider }
       )
     })
 
     await waitFor(() => {
-      expect(mockClient.compute.canUser.query).toHaveBeenCalledWith(["flavor_specs:create", "flavor_specs:delete"])
+      expect(mockClient.compute.canUser.query).toHaveBeenCalledWith(["flavors:add_project", "flavors:remove_project"])
     })
   })
 })

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/-components/Flavors/-components/ManageAccessModal.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/-components/Flavors/-components/ManageAccessModal.tsx
@@ -31,10 +31,9 @@ interface FlavorAccess {
 }
 
 const createPermissionsPromise = (client: TrpcClient) => {
-  return Promise.all([
-    client.compute.canUser.query("flavors:add_project"),
-    client.compute.canUser.query("flavors:remove_project"),
-  ]).then(([canAdd, canRemove]) => ({ canAdd, canRemove }))
+  return client.compute.canUser
+    .query(["flavors:add_project", "flavors:remove_project"])
+    .then(([canAdd, canRemove]) => ({ canAdd, canRemove }))
 }
 
 const createFlavorAccessPromise = (client: TrpcClient, project: string, flavorId: string) => {

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/-components/Flavors/List.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/-components/Flavors/List.tsx
@@ -35,7 +35,7 @@ const createFlavorsPromise = (
 }
 
 const createPermissionsPromise = (client: TrpcClient) => {
-  return client.compute.canUserBulk
+  return client.compute.canUser
     .query(["flavors:create", "flavors:delete", "flavors:list_projects"])
     .then(([canCreate, canDelete, canManageAccess]) => ({ canCreate, canDelete, canManageAccess }))
 }

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/-components/Images/apiHelpers.ts
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/-components/Images/apiHelpers.ts
@@ -43,7 +43,7 @@ export const createImagesPromise = (
 }
 
 export const createPermissionsPromise = (client: TrpcClient) => {
-  return client.compute.canUserBulk
+  return client.compute.canUser
     .query([
       "images:create",
       "images:delete",

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/flavors/$flavorId.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/flavors/$flavorId.tsx
@@ -60,7 +60,7 @@ function RouteComponent() {
     flavorId,
   })
 
-  const { data: permissionsData } = trpcReact.compute.canUserBulk.useQuery([
+  const { data: permissionsData } = trpcReact.compute.canUser.useQuery([
     "flavors:delete",
     "flavors:list_projects",
     "flavor_specs:create",

--- a/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/images/$imageId.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/accounts/$accountId/projects/$projectId/compute/images/$imageId.tsx
@@ -71,7 +71,7 @@ function RouteComponent() {
 
   const { data: image, status, error } = trpcReact.compute.getImageById.useQuery({ imageId: imageId })
 
-  const { data: permissionsData } = trpcReact.compute.canUserBulk.useQuery([
+  const { data: permissionsData } = trpcReact.compute.canUser.useQuery([
     "images:delete",
     "images:update",
     "images:create_member",

--- a/apps/aurora-portal/src/server/Compute/routers/permissionRouter.test.ts
+++ b/apps/aurora-portal/src/server/Compute/routers/permissionRouter.test.ts
@@ -98,35 +98,27 @@ describe("permissionRouter", () => {
 
     describe("Permission key validation", () => {
       it("should throw BAD_REQUEST for unknown permission", async () => {
-        await expect(caller.canUser("invalid:permission" as unknown as PermissionKey)).rejects.toThrow(
-          expect.objectContaining({
-            code: "BAD_REQUEST",
-          })
-        )
+        await expect(caller.canUser("invalid:permission" as unknown as PermissionKey)).rejects.toMatchObject({
+          code: "BAD_REQUEST",
+        })
       })
 
       it("should throw BAD_REQUEST for empty string", async () => {
-        await expect(caller.canUser("" as unknown as PermissionKey)).rejects.toThrow(
-          expect.objectContaining({
-            code: "BAD_REQUEST",
-          })
-        )
+        await expect(caller.canUser("" as unknown as PermissionKey)).rejects.toMatchObject({
+          code: "BAD_REQUEST",
+        })
       })
 
       it("should throw BAD_REQUEST for malformed permission key", async () => {
-        await expect(caller.canUser("just-a-string" as unknown as PermissionKey)).rejects.toThrow(
-          expect.objectContaining({
-            code: "BAD_REQUEST",
-          })
-        )
+        await expect(caller.canUser("just-a-string" as unknown as PermissionKey)).rejects.toMatchObject({
+          code: "BAD_REQUEST",
+        })
       })
 
       it("should throw BAD_REQUEST for partial permission key", async () => {
-        await expect(caller.canUser("servers" as unknown as PermissionKey)).rejects.toThrow(
-          expect.objectContaining({
-            code: "BAD_REQUEST",
-          })
-        )
+        await expect(caller.canUser("servers" as unknown as PermissionKey)).rejects.toMatchObject({
+          code: "BAD_REQUEST",
+        })
       })
     })
 

--- a/apps/aurora-portal/src/server/Compute/routers/permissionRouter.test.ts
+++ b/apps/aurora-portal/src/server/Compute/routers/permissionRouter.test.ts
@@ -5,6 +5,9 @@ import { AuroraPortalContext } from "../../context"
 import { permissionRouter } from "./permissionRouter"
 
 const createCaller = createCallerFactory(router(permissionRouter))
+type CanUserInput = Parameters<ReturnType<typeof createCaller>["canUser"]>[0]
+type PermissionKey = Extract<CanUserInput, string>
+type PermissionList = Extract<CanUserInput, PermissionKey[]>
 
 describe("permissionRouter", () => {
   let caller: ReturnType<typeof createCaller>
@@ -95,26 +98,34 @@ describe("permissionRouter", () => {
 
     describe("Permission key validation", () => {
       it("should throw BAD_REQUEST for unknown permission", async () => {
-        await expect(caller.canUser("invalid:permission")).rejects.toThrow(
-          new TRPCError({ code: "BAD_REQUEST", message: "Unknown permission: invalid:permission" })
+        await expect(caller.canUser("invalid:permission" as unknown as PermissionKey)).rejects.toThrow(
+          expect.objectContaining({
+            code: "BAD_REQUEST",
+          })
         )
       })
 
       it("should throw BAD_REQUEST for empty string", async () => {
-        await expect(caller.canUser("")).rejects.toThrow(
-          new TRPCError({ code: "BAD_REQUEST", message: "Unknown permission: " })
+        await expect(caller.canUser("" as unknown as PermissionKey)).rejects.toThrow(
+          expect.objectContaining({
+            code: "BAD_REQUEST",
+          })
         )
       })
 
       it("should throw BAD_REQUEST for malformed permission key", async () => {
-        await expect(caller.canUser("just-a-string")).rejects.toThrow(
-          new TRPCError({ code: "BAD_REQUEST", message: "Unknown permission: just-a-string" })
+        await expect(caller.canUser("just-a-string" as unknown as PermissionKey)).rejects.toThrow(
+          expect.objectContaining({
+            code: "BAD_REQUEST",
+          })
         )
       })
 
       it("should throw BAD_REQUEST for partial permission key", async () => {
-        await expect(caller.canUser("servers")).rejects.toThrow(
-          new TRPCError({ code: "BAD_REQUEST", message: "Unknown permission: servers" })
+        await expect(caller.canUser("servers" as unknown as PermissionKey)).rejects.toThrow(
+          expect.objectContaining({
+            code: "BAD_REQUEST",
+          })
         )
       })
     })
@@ -153,29 +164,46 @@ describe("permissionRouter", () => {
     })
 
     describe("Return type validation", () => {
-      it("should return boolean for all valid permissions", async () => {
-        const permissions = [
+      it("should return array of booleans for single permission", async () => {
+        const permissions: PermissionKey[] = [
           "servers:list",
           "servers:create",
           "flavors:create",
           "flavor_specs:list",
           "images:list",
-          "images:create",
         ]
 
         for (const permission of permissions) {
           const result = await caller.canUser(permission)
-          expect(typeof result).toBe("boolean")
+          expect(Array.isArray(result)).toBe(true)
+          expect(result).toHaveLength(1)
+          expect(typeof result[0]).toBe("boolean")
         }
+      })
+
+      it("should return array of booleans for array input", async () => {
+        const permissions: PermissionList = ["servers:list", "servers:create", "flavors:create"]
+        const result = await caller.canUser(permissions)
+
+        expect(Array.isArray(result)).toBe(true)
+        expect(result).toHaveLength(3)
+        result.forEach((item) => expect(typeof item).toBe("boolean"))
+      })
+
+      it("should return empty array for empty input", async () => {
+        const result = await caller.canUser([])
+
+        expect(Array.isArray(result)).toBe(true)
+        expect(result).toHaveLength(0)
       })
 
       it("should return consistent results for same permission", async () => {
         const result1 = await caller.canUser("servers:list")
         const result2 = await caller.canUser("servers:list")
 
-        expect(typeof result1).toBe("boolean")
-        expect(typeof result2).toBe("boolean")
-        expect(result1).toBe(result2) // Should be consistent
+        expect(Array.isArray(result1)).toBe(true)
+        expect(Array.isArray(result2)).toBe(true)
+        expect(result1).toEqual(result2)
       })
     })
 
@@ -199,9 +227,10 @@ describe("permissionRouter", () => {
 
         const callerWithoutProject = createCaller(mockContextWithoutProject)
 
-        // Should not throw and should return a boolean
+        // Should not throw and should return an array
         const result = await callerWithoutProject.canUser("servers:list")
-        expect(typeof result).toBe("boolean")
+        expect(Array.isArray(result)).toBe(true)
+        expect(result).toHaveLength(1)
       })
 
       it("should handle empty roles array", async () => {
@@ -223,9 +252,10 @@ describe("permissionRouter", () => {
 
         const callerWithNoRoles = createCaller(mockContextWithNoRoles)
 
-        // Should not throw and should return a boolean
+        // Should not throw and should return an array
         const result = await callerWithNoRoles.canUser("servers:list")
-        expect(typeof result).toBe("boolean")
+        expect(Array.isArray(result)).toBe(true)
+        expect(result).toHaveLength(1)
       })
 
       it("should handle different user roles", async () => {
@@ -260,7 +290,8 @@ describe("permissionRouter", () => {
 
           // Should handle any role configuration without throwing
           const result = await callerWithRoles.canUser("servers:list")
-          expect(typeof result).toBe("boolean")
+          expect(Array.isArray(result)).toBe(true)
+          expect(result).toHaveLength(1)
         }
       })
     })
@@ -286,318 +317,36 @@ describe("permissionRouter", () => {
 
     describe("Multiple operations", () => {
       it("should handle multiple permission checks in sequence", async () => {
-        const permissions = ["servers:list", "servers:create", "flavors:create", "images:list", "images:create"]
+        const permissions: PermissionKey[] = [
+          "servers:list",
+          "servers:create",
+          "flavors:create",
+          "images:list",
+          "images:create",
+        ]
 
         const results = []
         for (const permission of permissions) {
           const result = await caller.canUser(permission)
           results.push(result)
-          expect(typeof result).toBe("boolean")
+          expect(Array.isArray(result)).toBe(true)
+          expect(result).toHaveLength(1)
         }
 
-        // All results should be booleans
-        expect(results.every((result) => typeof result === "boolean")).toBe(true)
+        // All results should be arrays
+        expect(results.every((result) => Array.isArray(result))).toBe(true)
       })
 
       it("should handle concurrent permission checks", async () => {
-        const permissions = ["servers:list", "flavors:create", "images:list"]
+        const permissions: PermissionKey[] = ["servers:list", "flavors:create", "images:list"]
 
         const promises = permissions.map((permission) => caller.canUser(permission))
         const results = await Promise.all(promises)
 
         results.forEach((result) => {
-          expect(typeof result).toBe("boolean")
-        })
-      })
-    })
-  })
-
-  describe("Bulk permissions", () => {
-    describe("Array input validation", () => {
-      it("should accept array of valid permission strings", async () => {
-        const permissions = ["servers:list", "servers:create", "flavors:create"]
-        const result = await caller.canUserBulk(permissions)
-
-        expect(Array.isArray(result)).toBe(true)
-        expect(result).toHaveLength(3)
-        result.forEach((item) => expect(typeof item).toBe("boolean"))
-      })
-
-      it("should return empty array for empty input array", async () => {
-        const result = await caller.canUserBulk([])
-
-        expect(Array.isArray(result)).toBe(true)
-        expect(result).toHaveLength(0)
-      })
-
-      it("should throw BAD_REQUEST for array containing invalid permissions", async () => {
-        const permissions = ["servers:list", "invalid:permission", "flavors:create"]
-
-        await expect(caller.canUserBulk(permissions)).rejects.toThrow(
-          new TRPCError({ code: "BAD_REQUEST", message: "Unknown permission: invalid:permission" })
-        )
-      })
-
-      it("should throw BAD_REQUEST for array containing empty strings", async () => {
-        const permissions = ["servers:list", "", "flavors:create"]
-
-        await expect(caller.canUserBulk(permissions)).rejects.toThrow(
-          new TRPCError({ code: "BAD_REQUEST", message: "Unknown permission: " })
-        )
-      })
-
-      it("should throw BAD_REQUEST for array containing malformed permissions", async () => {
-        const permissions = ["servers:list", "just-a-string", "flavors:create"]
-
-        await expect(caller.canUserBulk(permissions)).rejects.toThrow(
-          new TRPCError({ code: "BAD_REQUEST", message: "Unknown permission: just-a-string" })
-        )
-      })
-    })
-
-    describe("Authentication validation with arrays", () => {
-      it("should throw UNAUTHORIZED for array input when no OpenStack session exists", async () => {
-        const mockContextWithoutOpenStack = {
-          ...mockContext,
-          openstack: null,
-        } as unknown as AuroraPortalContext
-        const callerWithoutOpenStack = createCaller(mockContextWithoutOpenStack)
-
-        await expect(callerWithoutOpenStack.canUserBulk(["servers:list", "flavors:create"])).rejects.toThrow(
-          new TRPCError({ code: "UNAUTHORIZED", message: "No valid OpenStack token found" })
-        )
-      })
-
-      it("should throw UNAUTHORIZED for array input when getToken returns null", async () => {
-        const mockOpenstackSessionWithNullToken = {
-          getToken: vi.fn(() => null),
-        }
-        const mockContextWithNullToken = {
-          ...mockContext,
-          openstack: mockOpenstackSessionWithNullToken,
-        } as unknown as AuroraPortalContext
-        const callerWithNullToken = createCaller(mockContextWithNullToken)
-
-        await expect(callerWithNullToken.canUserBulk(["servers:list", "flavors:create"])).rejects.toThrow(
-          new TRPCError({ code: "UNAUTHORIZED", message: "No valid OpenStack token found" })
-        )
-      })
-    })
-
-    describe("Bulk permission result consistency", () => {
-      it("should return same results for bulk check as individual checks", async () => {
-        const permissions = ["servers:list", "servers:create", "flavors:create", "images:list"]
-
-        // Get bulk results
-        const bulkResults = await caller.canUserBulk(permissions)
-
-        // Get individual results
-        const individualResults = await Promise.all(permissions.map((permission) => caller.canUser(permission)))
-
-        expect(bulkResults).toEqual(individualResults)
-      })
-
-      it("should maintain order of permissions in results", async () => {
-        const permissions = ["images:create", "servers:list", "flavors:delete", "servers:create"]
-
-        const result = await caller.canUserBulk(permissions)
-
-        expect(Array.isArray(result)).toBe(true)
-        expect(result).toHaveLength(4)
-
-        // Verify each position corresponds to the correct permission by checking individual results
-        for (let i = 0; i < permissions.length; i++) {
-          const individualResult = await caller.canUser(permissions[i])
-          expect(result[i]).toBe(individualResult)
-        }
-      })
-
-      it("should handle duplicate permissions in array", async () => {
-        const permissions = ["servers:list", "flavors:create", "servers:list", "images:list", "servers:list"]
-
-        const result = await caller.canUserBulk(permissions)
-
-        expect(Array.isArray(result)).toBe(true)
-        expect(result).toHaveLength(5)
-
-        // All servers:list results should be the same
-        const serversListResult = await caller.canUser("servers:list")
-        expect(result[0]).toBe(serversListResult) // First servers:list
-        expect(result[2]).toBe(serversListResult) // Second servers:list
-        expect(result[4]).toBe(serversListResult) // Third servers:list
-      })
-    })
-
-    describe("Large bulk operations", () => {
-      it("should handle large arrays of permissions", async () => {
-        const allPermissions = [
-          "servers:list",
-          "servers:create",
-          "servers:delete",
-          "servers:update",
-          "flavors:create",
-          "flavors:delete",
-          "flavors:update",
-          "flavors:list_projects",
-          "flavors:add_project",
-          "flavors:remove_project",
-          "flavor_specs:list",
-          "flavor_specs:create",
-          "flavor_specs:update",
-          "flavor_specs:delete",
-          "images:list",
-          "images:create",
-          "images:delete",
-          "images:update",
-        ]
-
-        const result = await caller.canUserBulk(allPermissions)
-
-        expect(Array.isArray(result)).toBe(true)
-        expect(result).toHaveLength(allPermissions.length)
-        result.forEach((item) => expect(typeof item).toBe("boolean"))
-      })
-
-      it("should handle mixed permission types efficiently", async () => {
-        const mixedPermissions = [
-          "servers:list",
-          "flavors:create",
-          "images:delete",
-          "flavor_specs:update",
-          "servers:create",
-          "images:list",
-          "flavors:delete",
-          "flavor_specs:list",
-        ]
-
-        const startTime = Date.now()
-        const result = await caller.canUserBulk(mixedPermissions)
-        const endTime = Date.now()
-
-        expect(Array.isArray(result)).toBe(true)
-        expect(result).toHaveLength(mixedPermissions.length)
-        result.forEach((item) => expect(typeof item).toBe("boolean"))
-
-        // Should complete in reasonable time (adjust threshold as needed)
-        expect(endTime - startTime).toBeLessThan(1000)
-      })
-    })
-
-    describe("Error handling in bulk operations", () => {
-      it("should stop processing and throw error on first invalid permission", async () => {
-        const permissions = ["servers:list", "flavors:create", "invalid:permission", "images:list"]
-
-        await expect(caller.canUserBulk(permissions)).rejects.toThrow(
-          new TRPCError({ code: "BAD_REQUEST", message: "Unknown permission: invalid:permission" })
-        )
-      })
-
-      it("should handle getToken errors during bulk operations", async () => {
-        const mockOpenstackSessionWithError = {
-          getToken: vi.fn(() => {
-            throw new Error("Token retrieval failed")
-          }),
-        }
-        const mockContextWithError = {
-          ...mockContext,
-          openstack: mockOpenstackSessionWithError,
-        } as unknown as AuroraPortalContext
-        const callerWithError = createCaller(mockContextWithError)
-
-        await expect(callerWithError.canUserBulk(["servers:list", "flavors:create"])).rejects.toThrow(
-          "Token retrieval failed"
-        )
-      })
-    })
-
-    describe("Context data handling with bulk operations", () => {
-      it("should handle missing project data for bulk permissions", async () => {
-        const mockOpenstackSessionWithoutProject = {
-          getToken: vi.fn(() => ({
-            tokenData: {
-              project: undefined,
-              user: { id: "test-user-id", name: "test-user", domain: { id: "default", name: "Default" } },
-              roles: [{ name: "member", id: "member-role-id" }],
-            },
-            authToken: "test-auth-token",
-          })),
-        }
-        const mockContextWithoutProject = {
-          ...mockContext,
-          openstack: mockOpenstackSessionWithoutProject,
-        } as unknown as AuroraPortalContext
-        const callerWithoutProject = createCaller(mockContextWithoutProject)
-
-        const permissions = ["servers:list", "flavors:create", "images:list"]
-        const result = await callerWithoutProject.canUserBulk(permissions)
-
-        expect(Array.isArray(result)).toBe(true)
-        expect(result).toHaveLength(3)
-        result.forEach((item) => expect(typeof item).toBe("boolean"))
-      })
-
-      it("should handle different user roles for bulk permissions", async () => {
-        const permissions = ["servers:list", "servers:create", "flavors:create"]
-        const rolesTestCases = [
-          [{ name: "admin", id: "admin-id" }],
-          [{ name: "member", id: "member-id" }],
-          [{ name: "reader", id: "reader-id" }],
-        ]
-
-        for (const roles of rolesTestCases) {
-          const mockOpenstackSessionWithRoles = {
-            getToken: vi.fn(() => ({
-              tokenData: {
-                project: { id: "test-project-id", name: "Test Project", domain: { id: "default", name: "Default" } },
-                user: { id: "test-user-id", name: "test-user", domain: { id: "default", name: "Default" } },
-                roles,
-              },
-              authToken: "test-auth-token",
-            })),
-          }
-          const mockContextWithRoles = {
-            ...mockContext,
-            openstack: mockOpenstackSessionWithRoles,
-          } as unknown as AuroraPortalContext
-          const callerWithRoles = createCaller(mockContextWithRoles)
-
-          const result = await callerWithRoles.canUserBulk(permissions)
           expect(Array.isArray(result)).toBe(true)
-          expect(result).toHaveLength(3)
-          result.forEach((item) => expect(typeof item).toBe("boolean"))
-        }
-      })
-    })
-
-    describe("Performance and concurrency with bulk operations", () => {
-      it("should handle concurrent bulk permission checks", async () => {
-        const permissionSets = [
-          ["servers:list", "servers:create"],
-          ["flavors:create", "flavors:delete"],
-          ["images:list", "images:create", "images:update"],
-        ]
-
-        const promises = permissionSets.map((permissions) => caller.canUserBulk(permissions))
-        const results = await Promise.all(promises)
-
-        expect(results).toHaveLength(3)
-        expect(results[0]).toHaveLength(2)
-        expect(results[1]).toHaveLength(2)
-        expect(results[2]).toHaveLength(3)
-
-        results.forEach((resultArray) => {
-          expect(Array.isArray(resultArray)).toBe(true)
-          resultArray.forEach((item) => expect(typeof item).toBe("boolean"))
+          expect(result).toHaveLength(1)
         })
-      })
-
-      it("should maintain consistency between sequential bulk calls", async () => {
-        const permissions = ["servers:list", "flavors:create", "images:list"]
-
-        const result1 = await caller.canUserBulk(permissions)
-        const result2 = await caller.canUserBulk(permissions)
-
-        expect(result1).toEqual(result2)
       })
     })
   })

--- a/apps/aurora-portal/src/server/Compute/routers/permissionRouter.ts
+++ b/apps/aurora-portal/src/server/Compute/routers/permissionRouter.ts
@@ -1,8 +1,8 @@
+import { z } from "zod"
 import { TRPCError } from "@trpc/server"
 import { AuroraPortalContext } from "@/server/context"
-import { protectedProcedure } from "../../trpc"
 import { loadPolicyEngine } from "@/server/policyEngineLoader"
-import { z } from "zod"
+import { protectedProcedure } from "../../trpc"
 
 const computePolicyEngine = loadPolicyEngine("compute.yaml")
 const imagePolicyEngine = loadPolicyEngine("image.yaml")
@@ -54,43 +54,57 @@ const POLICY_MAPPINGS = {
 
 type PolicyKey = keyof typeof POLICY_MAPPINGS
 
-// Helper function to validate a single permission
-const validatePermission = (permission: string): PolicyKey => {
-  const policyMapping = POLICY_MAPPINGS[permission as PolicyKey]
-  if (!policyMapping) {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: `Unknown permission: ${permission}`,
-    })
-  }
-  return permission as PolicyKey
-}
-
-// Helper function to check a single permission
-const checkSinglePermission = (ctx: AuroraPortalContext, permission: PolicyKey): boolean => {
+const checkSinglePermission = (ctx: AuroraPortalContext, permission: PolicyKey) => {
   const policyMapping = POLICY_MAPPINGS[permission]
   const policy = getPolicy(ctx, policyMapping.engine)
   return policy.check(policyMapping.rule)
 }
 
-export const permissionRouter = {
-  canUser: protectedProcedure.input(z.string()).query(async ({ ctx, input }): Promise<boolean> => {
-    const validatedPermission = validatePermission(input)
-    return checkSinglePermission(ctx, validatedPermission)
-  }),
+/**
+ * Zod schema for a valid permission key.
+ *
+ * This schema ensures that:
+ * - The value is a string.
+ * - The string is a known key in `POLICY_MAPPINGS` (e.g., "servers:list", "flavors:create").
+ *
+ * Any other string or non‑string input is rejected as invalid,
+ * resulting in a `BAD_REQUEST` error from tRPC before the handler runs.
+ * This approach is explicit and tightly coupled to the defined policy mappings.
+ *
+ * @type {import("zod").ZodType<PolicyKey>}
+ */
+const PERMISSION_KEY = z.custom<PolicyKey>((value) => {
+  if (typeof value !== "string" || !(value in POLICY_MAPPINGS)) {
+    return false
+  }
+  return value
+})
 
-  canUserBulk: protectedProcedure.input(z.array(z.string())).query(async ({ ctx, input }): Promise<boolean[]> => {
-    // Return empty array for empty input
-    if (input.length === 0) {
+/**
+ * Permission checking endpoint that determines whether a user has one or more specific permissions.
+ *
+ * Usage:
+ * - `canUser("servers:list")` → returns `[boolean]` (single permission check, always wrapped in array).
+ * - `canUser(["servers:list", "flavors:create"])` → returns `boolean[]` (bulk check, one result per permission in order).
+ *
+ * Input must be:
+ * - A single valid permission key (string in `POLICY_MAPPINGS`), or
+ * - An array of valid permission keys.
+ *
+ * Invalid keys or non‑string values are rejected with a `BAD_REQUEST` error before the handler runs.
+ * Empty array input returns an empty array (`[]`).
+ * Always returns `boolean[]` for consistent destructuring on the client.
+ */
+export const permissionRouter = {
+  canUser: protectedProcedure
+    .input(z.union([PERMISSION_KEY, z.array(PERMISSION_KEY)]))
+    .query(async ({ ctx, input }): Promise<boolean[]> => {
+      const permissions = typeof input === "string" ? [input] : input
+
+      if (permissions.length === 0) {
       return []
     }
 
-    // Validate all permissions first (fail fast on invalid permissions)
-    const validatedPermissions = input.map((permission) => validatePermission(permission))
-
-    // Check all permissions and return results in the same order
-    const results: boolean[] = validatedPermissions.map((permission) => checkSinglePermission(ctx, permission))
-
-    return results
+      return permissions.map((permission) => checkSinglePermission(ctx, permission))
   }),
 }

--- a/apps/aurora-portal/src/server/Compute/routers/permissionRouter.ts
+++ b/apps/aurora-portal/src/server/Compute/routers/permissionRouter.ts
@@ -77,7 +77,7 @@ const PERMISSION_KEY = z.custom<PolicyKey>((value) => {
   if (typeof value !== "string" || !Object.hasOwn(POLICY_MAPPINGS, value)) {
     return false
   }
-  return value
+  return true
 })
 
 /**

--- a/apps/aurora-portal/src/server/Compute/routers/permissionRouter.ts
+++ b/apps/aurora-portal/src/server/Compute/routers/permissionRouter.ts
@@ -74,7 +74,7 @@ const checkSinglePermission = (ctx: AuroraPortalContext, permission: PolicyKey) 
  * @type {import("zod").ZodType<PolicyKey>}
  */
 const PERMISSION_KEY = z.custom<PolicyKey>((value) => {
-  if (typeof value !== "string" || !(value in POLICY_MAPPINGS)) {
+  if (typeof value !== "string" || !Object.hasOwn(POLICY_MAPPINGS, value)) {
     return false
   }
   return value
@@ -102,9 +102,9 @@ export const permissionRouter = {
       const permissions = typeof input === "string" ? [input] : input
 
       if (permissions.length === 0) {
-      return []
-    }
+        return []
+      }
 
       return permissions.map((permission) => checkSinglePermission(ctx, permission))
-  }),
+    }),
 }

--- a/apps/aurora-portal/src/server/Compute/routers/permissionRouter.ts
+++ b/apps/aurora-portal/src/server/Compute/routers/permissionRouter.ts
@@ -67,18 +67,28 @@ const checkSinglePermission = (ctx: AuroraPortalContext, permission: PolicyKey) 
  * - The value is a string.
  * - The string is a known key in `POLICY_MAPPINGS` (e.g., "servers:list", "flavors:create").
  *
- * Any other string or non‑string input is rejected as invalid,
- * resulting in a `BAD_REQUEST` error from tRPC before the handler runs.
+ * Any other string or non‑string input, or any string that is not a key in `POLICY_MAPPINGS`,
+ * is rejected with a Zod `custom` issue whose message is of the form "Unknown permission: <key>"
+ * and a path `["permission"]`.
+ *
+ * This results in a `BAD_REQUEST` error from tRPC before the handler runs,
+ * which is useful for debugging and client‑side error handling.
  * This approach is explicit and tightly coupled to the defined policy mappings.
  *
  * @type {import("zod").ZodType<PolicyKey>}
  */
-const PERMISSION_KEY = z.custom<PolicyKey>((value) => {
-  if (typeof value !== "string" || !Object.hasOwn(POLICY_MAPPINGS, value)) {
-    return false
-  }
-  return true
-})
+const PERMISSION_KEY = z
+  .string()
+  .superRefine((value, ctx) => {
+    if (!Object.hasOwn(POLICY_MAPPINGS, value)) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Unknown permission: ${value}`,
+        path: ["permission"],
+      })
+    }
+  })
+  .transform((value) => value as PolicyKey)
 
 /**
  * Permission checking endpoint that determines whether a user has one or more specific permissions.

--- a/apps/aurora-portal/src/server/Compute/routers/permissionRouter.ts
+++ b/apps/aurora-portal/src/server/Compute/routers/permissionRouter.ts
@@ -67,12 +67,11 @@ const checkSinglePermission = (ctx: AuroraPortalContext, permission: PolicyKey) 
  * - The value is a string.
  * - The string is a known key in `POLICY_MAPPINGS` (e.g., "servers:list", "flavors:create").
  *
- * Any other string or non‑string input, or any string that is not a key in `POLICY_MAPPINGS`,
- * is rejected with a Zod `custom` issue whose message is of the form "Unknown permission: <key>"
- * and a path `["permission"]`.
+ * Any other string or non-string input, or any string that is not a key in `POLICY_MAPPINGS`,
+ * is rejected with a Zod `custom` issue whose message is of the form "Unknown permission: <key>".
  *
- * This results in a `BAD_REQUEST` error from tRPC before the handler runs,
- * which is useful for debugging and client‑side error handling.
+ * This results in a `BAD_REQUEST` error from tRPC before the handler runs.
+ * which is useful for debugging and client-side error handling.
  * This approach is explicit and tightly coupled to the defined policy mappings.
  *
  * @type {import("zod").ZodType<PolicyKey>}
@@ -84,7 +83,6 @@ const PERMISSION_KEY = z
       ctx.addIssue({
         code: "custom",
         message: `Unknown permission: ${value}`,
-        path: ["permission"],
       })
     }
   })

--- a/apps/aurora-portal/src/server/policyEngineLoader.ts
+++ b/apps/aurora-portal/src/server/policyEngineLoader.ts
@@ -2,13 +2,17 @@ import path from "path"
 import fs from "fs"
 import { createPolicyEngineFromFile } from "@cobaltcore-dev/policy-engine"
 
-// support custom policy overrides by checking if a file exists in the permission_custom_policies folder
+/**
+ * Load a policy engine, preferring a same-named file from permission_custom_policies
+ * and falling back to permission_policies when no override exists.
+ *
+ * @param fileName Allowed policy file name to load.
+ * @returns Policy engine instance created from the resolved policy file.
+ */
 export const loadPolicyEngine = (fileName: string) => {
-  let file: string
-  if (fs.existsSync(path.join(__dirname, `../../permission_custom_policies/${fileName}`))) {
-    file = path.join(__dirname, `../../permission_custom_policies/${fileName}`)
-  } else {
-    file = path.join(__dirname, `../../permission_policies/${fileName}`)
-  }
+  const customPath = path.join(__dirname, `../../permission_custom_policies/${fileName}`)
+  const defaultPath = path.join(__dirname, `../../permission_policies/${fileName}`)
+
+  const file = fs.existsSync(customPath) ? customPath : defaultPath
   return createPolicyEngineFromFile(file)
 }

--- a/apps/aurora-portal/src/server/policyEngineLoader.ts
+++ b/apps/aurora-portal/src/server/policyEngineLoader.ts
@@ -6,7 +6,7 @@ import { createPolicyEngineFromFile } from "@cobaltcore-dev/policy-engine"
  * Load a policy engine, preferring a same-named file from permission_custom_policies
  * and falling back to permission_policies when no override exists.
  *
- * @param fileName Allowed policy file name to load.
+ * @param fileName Policy file name to resolve and load.
  * @returns Policy engine instance created from the resolved policy file.
  */
 export const loadPolicyEngine = (fileName: string) => {


### PR DESCRIPTION
# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->
Replacing permission checks with centralized Zod validation. It also unifies single ```canUser``` and ```canUserBulk``` permission checks under ```canUser```, so now we use one consistent API path and response shape. Together, this reduces logic, improves security and validation around permission keys, and keeps permission behavior easier

# Changes Made

<!-- List the changes that were made in this pull request. -->
- Updated procedure by mergin canUserBulk in canUser, now canUser accept single and multiple permissions
- Replaced validation mechanism for permissions entirely with Zod
- Simplified policy engine file selection

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- Issue 690: cobaltcore-dev/aurora-dashboard/issues/690 (did changes as first part of this EPIC)

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified permission-checking behavior across compute screens and simplified permission validation/handling to make access-related UI more consistent.

* **Tests**
  * Added a comprehensive test suite for Manage Access UI covering permission-driven rendering and data fetching.
  * Updated spec-editing tests to align with consolidated permission checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->