### PR TITLE
chore(core): update base image to use internal mirror

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine 
+FROM keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/node:24-alpine
 LABEL source_repository="https://github.com/cobaltcore-dev/aurora-dashboard"
 
 # install git


### PR DESCRIPTION
## Summary
- Update Dockerfile to use keppel.eu-de-1.cloud.sap mirror instead of pulling directly from Docker Hub

## Test plan
- [ ] Build Docker image with the new base image
- [ ] Verify the image functions correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image registry source to use an alternative mirror while maintaining all other configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->