### PR TITLE
fix(aurora-portal): fixed race condition issue

### DIFF
--- a/apps/aurora-portal/src/client/routes/_auth/projects/$projectId/index.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/projects/$projectId/index.tsx
@@ -5,10 +5,6 @@ import { Trans } from "@lingui/react/macro"
 
 export const Route = createFileRoute("/_auth/projects/$projectId/")({
   component: RouteComponent,
-  loader: async ({ context, params }) => {
-    const project = await context.trpcClient?.project.getProjectById.query({ id: params.projectId })
-    return { description: project?.description ?? null }
-  },
 })
 
 interface ServiceCardProps {
@@ -37,7 +33,6 @@ function RouteComponent() {
   const { crumbProject, availableServices, projectId } = useLoaderData({
     from: "/_auth/projects/$projectId",
   })
-  const { description } = Route.useLoaderData()
 
   const serviceIndex = getServiceIndex(availableServices ?? [])
   const base = `/projects/${projectId}`
@@ -72,7 +67,6 @@ function RouteComponent() {
     <Stack direction="vertical" gap="6" className="pb-4">
       <div>
         <ContentHeading>{crumbProject?.name}</ContentHeading>
-        {description && <p className="text-theme-light mt-1 text-sm">{description}</p>}
       </div>
       {cards.length > 0 ? (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/apps/aurora-portal/src/server/Project/routers/projectRouter.ts
+++ b/apps/aurora-portal/src/server/Project/routers/projectRouter.ts
@@ -179,13 +179,14 @@ export const projectRouter = {
    * 2. A domain-scoped token (returns full info if user is domain admin)
    * 3. A project-scoped token (returns full info if scoped to the same project)
    *
-   * Since we're just reading basic metadata and the user's initial token already
-   * has visibility to projects they have access to, we don't need to rescope.
-   * Rescoping would add unnecessary overhead and complexity.
-   *
    * IMPORTANT: This should be called AFTER rescoping the session to the target project
-   * or a domain with admin privileges. Calling it with an unscoped or differently-scoped
-   * token may result in 403 FORBIDDEN if the user doesn't have sufficient privileges.
+   * or a domain with admin privileges. Calling it before rescoping may result in:
+   * - INTERNAL_SERVER_ERROR if the service catalog is not yet populated (identity service unavailable)
+   * - 403 FORBIDDEN response from OpenStack API if the token lacks sufficient privileges
+   *
+   * The procedure itself uses protectedProcedure (no automatic rescoping) for flexibility,
+   * allowing callers to decide the appropriate scope. However, in practice, it should be
+   * called after setCurrentScope() completes to ensure the service catalog is ready.
    *
    * If in the future we need to access project-specific resources (compute, network, etc.),
    * we should create a separate procedure using projectScopedProcedure.

--- a/apps/aurora-portal/src/server/Project/routers/projectRouter.ts
+++ b/apps/aurora-portal/src/server/Project/routers/projectRouter.ts
@@ -183,6 +183,10 @@ export const projectRouter = {
    * has visibility to projects they have access to, we don't need to rescope.
    * Rescoping would add unnecessary overhead and complexity.
    *
+   * IMPORTANT: This should be called AFTER rescoping the session to the target project
+   * or a domain with admin privileges. Calling it with an unscoped or differently-scoped
+   * token may result in 403 FORBIDDEN if the user doesn't have sufficient privileges.
+   *
    * If in the future we need to access project-specific resources (compute, network, etc.),
    * we should create a separate procedure using projectScopedProcedure.
    */


### PR DESCRIPTION
# Fix: Race condition on project page navigation

## Problem

When navigating to a project page immediately after login, users encountered an error:

```json
{
  "error": {
    "message": "Service identity (region: undefined, interface: public) not found.",
    "code": -32603
  }
}
```

The error disappeared after refreshing the page, indicating a race condition during initial load.

## Root Cause

The child route (`$projectId/index.tsx`) had its own loader that executed in parallel with the parent route loader (`$projectId.tsx`):

- **Parent loader**: Calls `setCurrentScope()` to rescope the OpenStack token to the project
- **Child loader**: Simultaneously calls `getProjectById()` which uses `ctx.openstack.service("identity")`

The race condition occurred because:

1. Parent starts rescoping the token → service catalog updates asynchronously
2. Child tries to access Identity service from catalog → catalog not ready yet
3. Result: `region: undefined` error

After page refresh, the token was already scoped correctly (from cookie), so no race condition occurred.

## Solution

Removed the loader from the child route (`$projectId/index.tsx`):

```diff
export const Route = createFileRoute("/_auth/projects/$projectId/")({
  component: RouteComponent,
-  loader: async ({ context, params }) => {
-    const project = await context.trpcClient?.project.getProjectById.query({ id: params.projectId })
-    return { description: project?.description ?? null }
-  },
})
```

Now only the parent loader executes, ensuring sequential execution:

1. `setCurrentScope()` completes → token rescoped, catalog updated
2. `getAvailableServices()` executes → catalog ready
3. Child component renders with data from parent loader

## Changes

- **Removed**: Parallel loader from `$projectId/index.tsx` that was causing race condition
- **Removed**: Unused project description display (was loaded by the removed loader)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Project description is no longer displayed when viewing project details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->