### PR TITLE
feat(bff): delete and import certificate of certificate-authority operations

### DIFF
--- a/apps/aurora-portal/src/server/Services/routers/pcaRouter.test.ts
+++ b/apps/aurora-portal/src/server/Services/routers/pcaRouter.test.ts
@@ -108,6 +108,7 @@ const createMockContext = (opts?: {
   getByIdCertificateParseError?: boolean
   createCAParseError?: boolean
   createCertificateParseError?: boolean
+  importCAParseError?: boolean
 }) => {
   const {
     noClavis = false,
@@ -117,6 +118,7 @@ const createMockContext = (opts?: {
     getByIdCertificateParseError = false,
     createCAParseError = false,
     createCertificateParseError = false,
+    importCAParseError = false,
   } = opts || {}
 
   const getMock = vi.fn().mockImplementation((url: string) => {
@@ -140,6 +142,8 @@ const createMockContext = (opts?: {
     let responseBody: unknown
     if (url.includes("/certificates")) {
       responseBody = createCertificateParseError ? { invalid: true } : validCreateCertificateResponse
+    } else if (url.includes(":importCertificate")) {
+      responseBody = importCAParseError ? { invalid: true } : validCreateCAResponse
     } else {
       responseBody = createCAParseError ? { invalid: true } : validCreateCAResponse
     }
@@ -498,6 +502,50 @@ describe("pcaRouter", () => {
         new TRPCError({
           code: "PARSE_ERROR",
           message: "Failed to parse response in pcaRouter.createCertificate",
+        })
+      )
+    })
+  })
+
+  describe("import", () => {
+    it("imports certificate for valid input", async () => {
+      const ctx = createMockContext()
+      const caller = createCaller(ctx as never)
+
+      const result = await caller.services.pca.import({
+        project_id: TEST_PROJECT_ID,
+        certificate_authority_id: "ca-1",
+        imported_certificate_chain:
+          "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHHC...ABC123==\n-----END CERTIFICATE-----",
+      })
+
+      expect(result).toEqual(validCreateCAResponse.certificate_authority)
+      expect(ctx.__postMock).toHaveBeenCalledWith(
+        "v1/certificate-authorities/ca-1:importCertificate",
+        expect.any(Object)
+      )
+      const [, request] = ctx.__postMock.mock.calls[ctx.__postMock.mock.calls.length - 1]
+      expect(JSON.parse(request.body)).toEqual({
+        imported_certificate_chain:
+          "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHHC...ABC123==\n-----END CERTIFICATE-----",
+      })
+    })
+
+    it("throws PARSE_ERROR on invalid import response payload", async () => {
+      const ctx = createMockContext({ importCAParseError: true })
+      const caller = createCaller(ctx as never)
+
+      await expect(
+        caller.services.pca.import({
+          project_id: TEST_PROJECT_ID,
+          certificate_authority_id: "ca-1",
+          imported_certificate_chain:
+            "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHHC...ABC123==\n-----END CERTIFICATE-----",
+        })
+      ).rejects.toThrow(
+        new TRPCError({
+          code: "PARSE_ERROR",
+          message: "Failed to parse response in pcaRouter.import",
         })
       )
     })

--- a/apps/aurora-portal/src/server/Services/routers/pcaRouter.test.ts
+++ b/apps/aurora-portal/src/server/Services/routers/pcaRouter.test.ts
@@ -149,7 +149,10 @@ const createMockContext = (opts?: {
     })
   })
 
+  const delMock = vi.fn().mockResolvedValue(undefined)
+
   const clavisService = {
+    del: delMock,
     get: getMock,
     post: postMock,
   }
@@ -172,6 +175,7 @@ const createMockContext = (opts?: {
     terminateSession: vi.fn(),
     getMultipartData: vi.fn(),
     __serviceMock: serviceMock,
+    __delMock: delMock,
     __getMock: getMock,
     __postMock: postMock,
   }
@@ -271,6 +275,38 @@ describe("pcaRouter", () => {
         new TRPCError({
           code: "PARSE_ERROR",
           message: "Failed to parse response in pcaRouter.getById",
+        })
+      )
+    })
+  })
+
+  describe("delete", () => {
+    it("deletes certificate authority for valid input", async () => {
+      const ctx = createMockContext()
+      const caller = createCaller(ctx as never)
+
+      const result = await caller.services.pca.delete({
+        project_id: TEST_PROJECT_ID,
+        certificate_authority_id: "ca-1",
+      })
+
+      expect(result).toBeUndefined()
+      expect(ctx.__delMock).toHaveBeenCalledWith("v1/certificate-authorities/ca-1")
+    })
+
+    it("throws INTERNAL_SERVER_ERROR when clavis service is unavailable", async () => {
+      const ctx = createMockContext({ noClavis: true })
+      const caller = createCaller(ctx as never)
+
+      await expect(
+        caller.services.pca.delete({
+          project_id: TEST_PROJECT_ID,
+          certificate_authority_id: "ca-1",
+        })
+      ).rejects.toThrow(
+        new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Clavis service is not available",
         })
       )
     })

--- a/apps/aurora-portal/src/server/Services/routers/pcaRouter.test.ts
+++ b/apps/aurora-portal/src/server/Services/routers/pcaRouter.test.ts
@@ -65,12 +65,49 @@ const validGetByIdCertificateResponse = {
   certificate: validCertificatesResponse.certificates[0],
 }
 
+const validCreateCAResponse = {
+  certificate_authority: {
+    id: "ca-new",
+    project_id: TEST_PROJECT_ID,
+    state: "CREATING" as const,
+    configuration: {
+      subject: {
+        common_name: "new-ca.example.com",
+      },
+    },
+  },
+}
+
+const validCreateCertificateResponse = {
+  certificate: {
+    id: "cert-new",
+    certificate_authority_id: "ca-1",
+    project_id: TEST_PROJECT_ID,
+    certificate: {
+      pem: "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHHC...ABC123==\n-----END CERTIFICATE-----",
+      validity: {
+        not_before: 1705315200,
+        not_after: 1736851200,
+      },
+    },
+    configuration: {
+      validity: {
+        not_before: 1705315200,
+        not_after: 1736851200,
+      },
+    },
+    csr: "-----BEGIN CERTIFICATE REQUEST-----\nMIIBkTCB+wIJAKHHC...ABC123==\n-----END CERTIFICATE REQUEST-----",
+  },
+}
+
 const createMockContext = (opts?: {
   noClavis?: boolean
   parseError?: boolean
   certificateParseError?: boolean
   getByIdParseError?: boolean
   getByIdCertificateParseError?: boolean
+  createCAParseError?: boolean
+  createCertificateParseError?: boolean
 }) => {
   const {
     noClavis = false,
@@ -78,6 +115,8 @@ const createMockContext = (opts?: {
     certificateParseError = false,
     getByIdParseError = false,
     getByIdCertificateParseError = false,
+    createCAParseError = false,
+    createCertificateParseError = false,
   } = opts || {}
 
   const getMock = vi.fn().mockImplementation((url: string) => {
@@ -97,8 +136,22 @@ const createMockContext = (opts?: {
     })
   })
 
+  const postMock = vi.fn().mockImplementation((url: string) => {
+    let responseBody: unknown
+    if (url.includes("/certificates")) {
+      responseBody = createCertificateParseError ? { invalid: true } : validCreateCertificateResponse
+    } else {
+      responseBody = createCAParseError ? { invalid: true } : validCreateCAResponse
+    }
+
+    return Promise.resolve({
+      json: vi.fn().mockResolvedValue(responseBody),
+    })
+  })
+
   const clavisService = {
     get: getMock,
+    post: postMock,
   }
 
   const serviceMock = vi.fn().mockImplementation((serviceName: string) => {
@@ -120,6 +173,7 @@ const createMockContext = (opts?: {
     getMultipartData: vi.fn(),
     __serviceMock: serviceMock,
     __getMock: getMock,
+    __postMock: postMock,
   }
 }
 
@@ -318,6 +372,99 @@ describe("pcaRouter", () => {
         new TRPCError({
           code: "PARSE_ERROR",
           message: "Failed to parse response in pcaRouter.getByIdCertificate",
+        })
+      )
+    })
+  })
+
+  describe("create", () => {
+    it("creates certificate authority for valid input", async () => {
+      const ctx = createMockContext()
+      const caller = createCaller(ctx as never)
+
+      const result = await caller.services.pca.create({
+        project_id: TEST_PROJECT_ID,
+        configuration: {
+          subject: {
+            common_name: "new-ca.example.com",
+          },
+        },
+      })
+
+      expect(result).toEqual(validCreateCAResponse.certificate_authority)
+      expect(ctx.__postMock).toHaveBeenCalledWith("v1/certificate-authorities", expect.any(Object))
+    })
+
+    it("throws PARSE_ERROR on invalid create response payload", async () => {
+      const ctx = createMockContext({ createCAParseError: true })
+      const caller = createCaller(ctx as never)
+
+      await expect(
+        caller.services.pca.create({
+          project_id: TEST_PROJECT_ID,
+          configuration: {
+            subject: {
+              common_name: "new-ca.example.com",
+            },
+          },
+        })
+      ).rejects.toThrow(
+        new TRPCError({
+          code: "PARSE_ERROR",
+          message: "Failed to parse response in pcaRouter.create",
+        })
+      )
+    })
+  })
+
+  describe("createCertificate", () => {
+    it("creates certificate for valid input", async () => {
+      const ctx = createMockContext()
+      const caller = createCaller(ctx as never)
+
+      const result = await caller.services.pca.createCertificate({
+        project_id: TEST_PROJECT_ID,
+        certificate_authority_id: "ca-1",
+        certificate: {
+          configuration: {
+            validity: {
+              not_before: 1705315200,
+              not_after: 1736851200,
+            },
+          },
+          csr: "-----BEGIN CERTIFICATE REQUEST-----\nMIIBkTCB+wIJAKHHC...ABC123==\n-----END CERTIFICATE REQUEST-----",
+        },
+      })
+
+      expect(result).toEqual(validCreateCertificateResponse.certificate)
+      expect(ctx.__postMock).toHaveBeenCalledWith(
+        "v1/certificate-authorities/ca-1/certificates",
+        expect.any(Object)
+      )
+    })
+
+    it("throws PARSE_ERROR on invalid create certificate response payload", async () => {
+      const ctx = createMockContext({ createCertificateParseError: true })
+      const caller = createCaller(ctx as never)
+
+      await expect(
+        caller.services.pca.createCertificate({
+          project_id: TEST_PROJECT_ID,
+          certificate_authority_id: "ca-1",
+          certificate: {
+            configuration: {
+              validity: {
+                not_before: 1705315200,
+                not_after: 1736851200,
+              },
+            },
+            csr: "-----BEGIN CERTIFICATE REQUEST-----\nMIIBkTCB+wIJAKHHC...ABC123==\n-----END CERTIFICATE REQUEST-----",
+          },
+        })
+      ).rejects.toThrow(
+        new TRPCError({
+          code: "PARSE_ERROR",
+          message: "Failed to parse response in pcaRouter.createCertificate",
         })
       )
     })

--- a/apps/aurora-portal/src/server/Services/routers/pcaRouter.test.ts
+++ b/apps/aurora-portal/src/server/Services/routers/pcaRouter.test.ts
@@ -437,10 +437,7 @@ describe("pcaRouter", () => {
       })
 
       expect(result).toEqual(validCreateCertificateResponse.certificate)
-      expect(ctx.__postMock).toHaveBeenCalledWith(
-        "v1/certificate-authorities/ca-1/certificates",
-        expect.any(Object)
-      )
+      expect(ctx.__postMock).toHaveBeenCalledWith("v1/certificate-authorities/ca-1/certificates", expect.any(Object))
     })
 
     it("throws PARSE_ERROR on invalid create certificate response payload", async () => {

--- a/apps/aurora-portal/src/server/Services/routers/pcaRouter.ts
+++ b/apps/aurora-portal/src/server/Services/routers/pcaRouter.ts
@@ -37,7 +37,7 @@ export const pcaRouter = {
    */
   create: projectScopedProcedure
     .input(CertificateAuthorityCreateSchema)
-    .query(async ({ input, ctx }): Promise<CertificateAuthority> => {
+    .mutation(async ({ input, ctx }): Promise<CertificateAuthority> => {
       return withErrorHandling(async () => {
         const pca = ctx.openstack?.service("clavis")
         validateOpenstackService(pca, "clavis")
@@ -79,7 +79,7 @@ export const pcaRouter = {
     }),
   createCertificate: projectScopedProcedure
     .input(CreateCertificateInputSchema)
-    .query(async ({ input, ctx }): Promise<Certificate> => {
+    .mutation(async ({ input, ctx }): Promise<Certificate> => {
       return withErrorHandling(async () => {
         const pca = ctx.openstack?.service("clavis")
         validateOpenstackService(pca, "clavis")

--- a/apps/aurora-portal/src/server/Services/routers/pcaRouter.ts
+++ b/apps/aurora-portal/src/server/Services/routers/pcaRouter.ts
@@ -12,6 +12,7 @@ import {
   CertificateIdInputSchema,
   CertificateResponseSchema,
   CertificateAuthorityCreateSchema,
+  CreateCertificateInputSchema,
 } from "../types/pca"
 
 /** PCA (Private Certificate Authority) - Clavis service for certificate authority management  */
@@ -47,7 +48,7 @@ export const pcaRouter = {
         // Certificate Authority creation initiated successfully (async operation)
         return parseOrThrow(CertificateAuthorityResponseSchema, data, "pcaRouter.create").certificate_authority
       }, "create certificate authority")
-  }),
+    }),
   getById: projectScopedProcedure
     .input(CertificateAuthorityIdInputSchema)
     .query(async ({ input, ctx }): Promise<CertificateAuthority> => {
@@ -75,6 +76,20 @@ export const pcaRouter = {
 
         return parseOrThrow(CertificatesListSchema, data, "pcaRouter.listCertificates").certificates
       }, "list certificates for certificate authority")
+    }),
+  createCertificate: projectScopedProcedure
+    .input(CreateCertificateInputSchema)
+    .query(async ({ input, ctx }): Promise<Certificate> => {
+      return withErrorHandling(async () => {
+        const pca = ctx.openstack?.service("clavis")
+        validateOpenstackService(pca, "clavis")
+
+        const url = `${PCA_BASE_URL}/${input.certificate_authority_id}/certificates`
+        const response = await pca.post(url, { body: JSON.stringify(input.certificate) })
+        const data = await response.json()
+
+        return parseOrThrow(CertificateResponseSchema, data, "pcaRouter.createCertificate").certificate
+      }, "create certificate for certificate authority")
     }),
   getByIdCertificate: projectScopedProcedure
     .input(CertificateIdInputSchema)

--- a/apps/aurora-portal/src/server/Services/routers/pcaRouter.ts
+++ b/apps/aurora-portal/src/server/Services/routers/pcaRouter.ts
@@ -63,6 +63,20 @@ export const pcaRouter = {
         return parseOrThrow(CertificateAuthorityResponseSchema, data, "pcaRouter.getById").certificate_authority
       }, "get certificate authority details")
     }),
+  // Permanently deletes a Certificate Authority. This operation is irreversible.
+  delete: projectScopedProcedure
+    .input(CertificateAuthorityIdInputSchema)
+    .mutation(async ({ input, ctx }): Promise<void> => {
+      return withErrorHandling(async () => {
+        const pca = ctx.openstack?.service("clavis")
+        validateOpenstackService(pca, "clavis")
+
+        const url = `${PCA_BASE_URL}/${input.certificate_authority_id}`
+        // 204 Certificate Authority deleted successfully
+        await pca.del(url)
+      }, "delete certificate authority")
+    }),
+  //
   listCertificates: projectScopedProcedure
     .input(CertificateAuthorityIdInputSchema)
     .query(async ({ input, ctx }): Promise<Certificate[]> => {

--- a/apps/aurora-portal/src/server/Services/routers/pcaRouter.ts
+++ b/apps/aurora-portal/src/server/Services/routers/pcaRouter.ts
@@ -11,6 +11,7 @@ import {
   CertificateAuthorityResponseSchema,
   CertificateIdInputSchema,
   CertificateResponseSchema,
+  CertificateAuthorityCreateSchema,
 } from "../types/pca"
 
 /** PCA (Private Certificate Authority) - Clavis service for certificate authority management  */
@@ -27,6 +28,25 @@ export const pcaRouter = {
 
       return parseOrThrow(CertificateAuthoritiesListSchema, data, "pcaRouter.list").certificate_authorities
     }, "list certificate authorities")
+  }),
+  /**
+   * Creates a new Certificate Authority (CA).
+   * The CA is created in CREATING state and transitions to AWAITING_CERTIFICATE state once its CSR has been generated.
+   * CA in AWAITING_CERTIFICATE can't issue end-entity certificates, and needs to have its certificate imported - see the respective importCertificate endpoint.
+   */
+  create: projectScopedProcedure
+    .input(CertificateAuthorityCreateSchema)
+    .query(async ({ input, ctx }): Promise<CertificateAuthority> => {
+      return withErrorHandling(async () => {
+        const pca = ctx.openstack?.service("clavis")
+        validateOpenstackService(pca, "clavis")
+
+        const response = await pca.post(PCA_BASE_URL, { body: JSON.stringify(input) })
+        const data = await response.json()
+
+        // Certificate Authority creation initiated successfully (async operation)
+        return parseOrThrow(CertificateAuthorityResponseSchema, data, "pcaRouter.create").certificate_authority
+      }, "create certificate authority")
   }),
   getById: projectScopedProcedure
     .input(CertificateAuthorityIdInputSchema)

--- a/apps/aurora-portal/src/server/Services/routers/pcaRouter.ts
+++ b/apps/aurora-portal/src/server/Services/routers/pcaRouter.ts
@@ -13,6 +13,7 @@ import {
   CertificateResponseSchema,
   CertificateAuthorityCreateSchema,
   CreateCertificateInputSchema,
+  CertificateAuthorityImportInputSchema,
 } from "../types/pca"
 
 /** PCA (Private Certificate Authority) - Clavis service for certificate authority management  */
@@ -76,7 +77,27 @@ export const pcaRouter = {
         await pca.del(url)
       }, "delete certificate authority")
     }),
-  //
+  /**
+   * Imports Certificate Authority certificate
+   * Transitioning the CA from AWAITING_CERTIFICATE to READY state
+   * after which the CA becomes fully operational and can issue certificates to end entities
+   */
+  import: projectScopedProcedure
+    .input(CertificateAuthorityImportInputSchema)
+    .mutation(async ({ input, ctx }): Promise<CertificateAuthority> => {
+      return withErrorHandling(async () => {
+        const pca = ctx.openstack?.service("clavis")
+        validateOpenstackService(pca, "clavis")
+
+        const url = `${PCA_BASE_URL}/${input.certificate_authority_id}:importCertificate`
+        const response = await pca.post(url, {
+          body: JSON.stringify({ imported_certificate_chain: input.imported_certificate_chain }),
+        })
+        const data = await response.json()
+
+        return parseOrThrow(CertificateAuthorityResponseSchema, data, "pcaRouter.import").certificate_authority
+      }, "import certificate of certificate authority")
+    }),
   listCertificates: projectScopedProcedure
     .input(CertificateAuthorityIdInputSchema)
     .query(async ({ input, ctx }): Promise<Certificate[]> => {

--- a/apps/aurora-portal/src/server/Services/types/pca.test.ts
+++ b/apps/aurora-portal/src/server/Services/types/pca.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect } from "vitest"
 import {
   CertificateAuthoritiesListSchema,
+  CertificateAuthorityCreateSchema,
   CertificateAuthorityResponseSchema,
   CertificateAuthoritySchema,
+  CertificateConfigurationSchema,
   CertificateAuthorityIdInputSchema,
   CertificateIdInputSchema,
   CertificateResponseSchema,
   CertificateSchema,
   CertificatesListSchema,
+  CreateCertificateInputSchema,
 } from "./pca"
 import { omit } from "@/server/helpers/object"
 
@@ -767,6 +770,83 @@ describe("PCA (Private Certificate Authority) Schema Validation", () => {
           certificate_authority_id: "ca-456",
         }).success
       ).toBe(true)
+    })
+  })
+
+  describe("CertificateAuthorityCreateSchema", () => {
+    it("should validate create input with subject.common_name", () => {
+      expect(
+        CertificateAuthorityCreateSchema.safeParse({
+          configuration: {
+            subject: { common_name: "ca.example.com" },
+          },
+        }).success
+      ).toBe(true)
+    })
+
+    it("should reject create input without subject.common_name", () => {
+      expect(
+        CertificateAuthorityCreateSchema.safeParse({
+          configuration: {
+            subject: {},
+          },
+        }).success
+      ).toBe(false)
+    })
+  })
+
+  describe("CertificateConfigurationSchema", () => {
+    it("should validate certificate configuration payload", () => {
+      expect(
+        CertificateConfigurationSchema.safeParse({
+          validity: {
+            not_after: 1736851200,
+            not_before: 1705315200,
+          },
+        }).success
+      ).toBe(true)
+    })
+
+    it("should reject certificate configuration payload without validity", () => {
+      expect(CertificateConfigurationSchema.safeParse({}).success).toBe(false)
+    })
+  })
+
+  describe("CreateCertificateInputSchema", () => {
+    it("should validate create certificate input", () => {
+      expect(
+        CreateCertificateInputSchema.safeParse({
+          project_id: "project-1",
+          certificate_authority_id: "ca-123",
+          certificate: {
+            configuration: {
+              validity: {
+                not_after: 1736851200,
+                not_before: 1705315200,
+              },
+            },
+            csr: "-----BEGIN CERTIFICATE REQUEST-----\n...\n-----END CERTIFICATE REQUEST-----",
+          },
+        }).success
+      ).toBe(true)
+    })
+
+    it("should reject create certificate input with empty certificate_authority_id", () => {
+      expect(
+        CreateCertificateInputSchema.safeParse({
+          project_id: "project-1",
+          certificate_authority_id: "",
+          certificate: {
+            configuration: {
+              validity: {
+                not_after: 1736851200,
+                not_before: 1705315200,
+              },
+            },
+            csr: "-----BEGIN CERTIFICATE REQUEST-----\n...\n-----END CERTIFICATE REQUEST-----",
+          },
+        }).success
+      ).toBe(false)
     })
   })
 

--- a/apps/aurora-portal/src/server/Services/types/pca.test.ts
+++ b/apps/aurora-portal/src/server/Services/types/pca.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest"
 import {
   CertificateAuthoritiesListSchema,
   CertificateAuthorityCreateSchema,
+  CertificateAuthorityImportInputSchema,
   CertificateAuthorityResponseSchema,
   CertificateAuthoritySchema,
   CertificateConfigurationSchema,
@@ -770,6 +771,38 @@ describe("PCA (Private Certificate Authority) Schema Validation", () => {
           certificate_authority_id: "ca-456",
         }).success
       ).toBe(true)
+    })
+  })
+
+  describe("CertificateAuthorityImportInputSchema", () => {
+    it("should validate import input with all required fields", () => {
+      expect(
+        CertificateAuthorityImportInputSchema.safeParse({
+          project_id: "project-1",
+          certificate_authority_id: "ca-123",
+          imported_certificate_chain:
+            "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHHC...ABC123==\n-----END CERTIFICATE-----",
+        }).success
+      ).toBe(true)
+    })
+
+    it("should reject import input without imported_certificate_chain", () => {
+      expect(
+        CertificateAuthorityImportInputSchema.safeParse({
+          project_id: "project-1",
+          certificate_authority_id: "ca-123",
+        }).success
+      ).toBe(false)
+    })
+
+    it("should reject import input with empty imported_certificate_chain", () => {
+      expect(
+        CertificateAuthorityImportInputSchema.safeParse({
+          project_id: "project-1",
+          certificate_authority_id: "ca-123",
+          imported_certificate_chain: "",
+        }).success
+      ).toBe(false)
     })
   })
 

--- a/apps/aurora-portal/src/server/Services/types/pca.ts
+++ b/apps/aurora-portal/src/server/Services/types/pca.ts
@@ -77,7 +77,7 @@ export const CertificateAuthoritiesListSchema = z.object({
   certificate_authorities: z.array(CertificateAuthoritySchema),
 })
 
-// Used by: /v1/certificate-authorities -  Create new Certificate Authority
+// Used by: /v1/certificate-authorities - Create new Certificate Authority
 export const CertificateAuthorityCreateSchema = z.object({
   configuration: z.object({
     subject: CertificateAuthoritySubjectSchema,
@@ -90,15 +90,17 @@ export const CertificateAuthorityCreateSchema = z.object({
  * Used by:
  * - GET /v1/certificate-authorities/{certificate_authority_id} - Show Certificate Authority details
  * - DELETE /v1/certificate-authorities/{certificate_authority_id} - Delete Certificate Authority
- * - POST /v1/certificate-authorities/{certificate_authority_id}:importCertificate - Import certificate of Certificate Authority
- *
  * - GET /v1/certificate-authorities/{certificate_authority_id}/certificates - List Certificates
- * - POST /v1/certificate-authorities/{certificate_authority_id}/certificates - Create new Certificate
  *
  */
 export const CertificateAuthorityIdInputSchema = z.object({
   project_id: z.string(),
   certificate_authority_id: z.string().min(1),
+})
+
+// Used by: /v1/certificate-authorities/{certificate_authority_id}:importCertificate - Import certificate of Certificate Authority
+export const CertificateAuthorityImportInputSchema = CertificateAuthorityIdInputSchema.extend({
+  imported_certificate_chain: z.string().min(1),
 })
 
 // Used by: /v1/certificate-authorities/{certificate_authority_id}/certificates/{certificate_id} - Get Certificate details

--- a/apps/aurora-portal/src/server/Services/types/pca.ts
+++ b/apps/aurora-portal/src/server/Services/types/pca.ts
@@ -111,11 +111,8 @@ export const CertificateIdInputSchema = CertificateAuthorityIdInputSchema.extend
   certificate_id: z.string().min(1),
 })
 
-const CertificateConfigurationSchema = z.object({
-  csr: z.string(),
-  configuration: z.object({
-    validity: CertificateValiditySchema,
-  }),
+export const CertificateConfigurationSchema = z.object({
+  validity: CertificateValiditySchema,
 })
 
 // Used by: /v1/certificate-authorities/{certificate_authority_id}/certificates - Create new Certificate
@@ -124,14 +121,16 @@ export const CreateCertificateInputSchema = z.object({
   certificate_authority_id: z.string().min(1),
   certificate: z.object({
     configuration: CertificateConfigurationSchema,
+    csr: z.string(),
   }),
 })
 
 export const CertificateSchema = z.object({
-  ...CertificateConfigurationSchema.shape,
   certificate: CertificateAuthorityCertificateSchema,
   certificate_authority_id: z.string(),
   certificate_chain: CertificateAuthorityCertificateChainSchema.optional(),
+  configuration: CertificateConfigurationSchema,
+  csr: z.string().optional(),
   id: z.string(),
   project_id: z.string(),
 })

--- a/apps/aurora-portal/src/server/Services/types/pca.ts
+++ b/apps/aurora-portal/src/server/Services/types/pca.ts
@@ -111,14 +111,27 @@ export const CertificateIdInputSchema = CertificateAuthorityIdInputSchema.extend
   certificate_id: z.string().min(1),
 })
 
-export const CertificateSchema = z.object({
-  certificate: CertificateAuthorityCertificateSchema,
-  certificate_authority_id: z.string(),
-  certificate_chain: CertificateAuthorityCertificateChainSchema.optional(),
+const CertificateConfigurationSchema = z.object({
+  csr: z.string(),
   configuration: z.object({
     validity: CertificateValiditySchema,
   }),
-  csr: z.string().optional(),
+})
+
+// Used by: /v1/certificate-authorities/{certificate_authority_id}/certificates - Create new Certificate
+export const CreateCertificateInputSchema = z.object({
+  project_id: z.string(),
+  certificate_authority_id: z.string().min(1),
+  certificate: z.object({
+    configuration: CertificateConfigurationSchema,
+  }),
+})
+
+export const CertificateSchema = z.object({
+  ...CertificateConfigurationSchema.shape,
+  certificate: CertificateAuthorityCertificateSchema,
+  certificate_authority_id: z.string(),
+  certificate_chain: CertificateAuthorityCertificateChainSchema.optional(),
   id: z.string(),
   project_id: z.string(),
 })

--- a/apps/aurora-portal/src/server/Services/types/pca.ts
+++ b/apps/aurora-portal/src/server/Services/types/pca.ts
@@ -78,6 +78,18 @@ export const CertificateAuthoritiesListSchema = z.object({
 })
 
 /**
+ * Input schema for creating a Certificate Authority.
+ *
+ * Used by:
+ * - POST /v1/certificate-authorities - Create new Certificate Authority
+ */
+export const CertificateAuthorityCreateSchema = z.object({
+  configuration: z.object({
+    subject: CertificateAuthoritySubjectSchema,
+  }),
+})
+
+/**
  * Input schema for Certificate Authority resource identification.
  *
  * Used by:

--- a/apps/aurora-portal/src/server/Services/types/pca.ts
+++ b/apps/aurora-portal/src/server/Services/types/pca.ts
@@ -77,12 +77,7 @@ export const CertificateAuthoritiesListSchema = z.object({
   certificate_authorities: z.array(CertificateAuthoritySchema),
 })
 
-/**
- * Input schema for creating a Certificate Authority.
- *
- * Used by:
- * - POST /v1/certificate-authorities - Create new Certificate Authority
- */
+// Used by: /v1/certificate-authorities -  Create new Certificate Authority
 export const CertificateAuthorityCreateSchema = z.object({
   configuration: z.object({
     subject: CertificateAuthoritySubjectSchema,


### PR DESCRIPTION
# Summary
Implemented Clavis PCA integration for delete and import procedures with schemas and corresponding tests

# Changes Made
<!-- List the changes that were made in this pull request. -->
- Added delete certificate-authority procedure
- Implemented import certificate of certificate-authority procedure
- Validated API with Zod schemas
- Covered new procedures and schemas with tests

# Related Issues

<!-- List any related issues or tickets, including links to them. -->
- Issue 778: cobaltcore-dev/aurora-dashboard/issues/778

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to delete certificate authorities permanently.
  * Added support for importing CA certificate chains with validation.

* **Tests**
  * Expanded test coverage for certificate authority import and delete operations, including error scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cobaltcore-dev/aurora-dashboard/pull/777)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->