### PR TITLE
fix(aurora-portal): expand active nav section on navigation

### DIFF
--- a/apps/aurora-portal/src/client/routes/_auth/projects/-components/SideNavBar.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/projects/-components/SideNavBar.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useMatches, useParams } from "@tanstack/react-router"
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { getServiceIndex } from "@/server/Authentication/helpers"
 import { SideNavigation, SideNavigationList, SideNavigationItem } from "@cloudoperators/juno-ui-components/index"
 import { useLingui } from "@lingui/react/macro"
@@ -107,12 +107,7 @@ export const SideNavBar = ({ projectId, projectName, availableServices }: SideNa
   ]
 
   const isOverviewActive = activeSection === null
-
-  useEffect(() => {
-    if (activeSection) {
-      setOpenSections((prev) => ({ ...prev, [activeSection]: true }))
-    }
-  }, [activeSection])
+  const isOpen = (section: string) => openSections[section as keyof typeof openSections] || activeSection === section
 
   return (
     <SideNavigation ariaLabel="Project Side Navigation" onActiveItemChange={() => {}}>
@@ -126,7 +121,7 @@ export const SideNavBar = ({ projectId, projectName, availableServices }: SideNa
           />
           <SideNavigationItem
             label={t`Compute`}
-            open={openSections.compute}
+            open={isOpen("compute")}
             onClick={() => setOpenSections((prev) => ({ ...prev, compute: !prev.compute }))}
           >
             {computeServices.map(({ service, label, to, params }) => (
@@ -142,7 +137,7 @@ export const SideNavBar = ({ projectId, projectName, availableServices }: SideNa
           {networkServices.length > 0 && (
             <SideNavigationItem
               label={t`Network`}
-              open={openSections.network}
+              open={isOpen("network")}
               onClick={() => setOpenSections((prev) => ({ ...prev, network: !prev.network }))}
             >
               {networkServices.map(({ service, label, to, params }) => (
@@ -159,7 +154,7 @@ export const SideNavBar = ({ projectId, projectName, availableServices }: SideNa
           {storageServices.length > 0 && (
             <SideNavigationItem
               label={t`Storage`}
-              open={openSections.storage}
+              open={isOpen("storage")}
               onClick={() => setOpenSections((prev) => ({ ...prev, storage: !prev.storage }))}
             >
               {storageServices.map(({ service, label, to, params }) => {
@@ -182,7 +177,7 @@ export const SideNavBar = ({ projectId, projectName, availableServices }: SideNa
           {clavisServices.length > 0 && (
             <SideNavigationItem
               label={t`Services`}
-              open={openSections.services}
+              open={isOpen("services")}
               onClick={() => setOpenSections((prev) => ({ ...prev, services: !prev.services }))}
             >
               {clavisServices.map(({ service, label, to, params }) => (

--- a/apps/aurora-portal/src/client/routes/_auth/projects/-components/SideNavBar.tsx
+++ b/apps/aurora-portal/src/client/routes/_auth/projects/-components/SideNavBar.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useMatches, useParams } from "@tanstack/react-router"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { getServiceIndex } from "@/server/Authentication/helpers"
 import { SideNavigation, SideNavigationList, SideNavigationItem } from "@cloudoperators/juno-ui-components/index"
 import { useLingui } from "@lingui/react/macro"
@@ -107,6 +107,12 @@ export const SideNavBar = ({ projectId, projectName, availableServices }: SideNa
   ]
 
   const isOverviewActive = activeSection === null
+
+  useEffect(() => {
+    if (activeSection) {
+      setOpenSections((prev) => ({ ...prev, [activeSection]: true }))
+    }
+  }, [activeSection])
 
   return (
     <SideNavigation ariaLabel="Project Side Navigation" onActiveItemChange={() => {}}>


### PR DESCRIPTION
# Summary

When navigating to a service whose parent section was collapsed, automatically expand that section so the active item is visible.

Closes #845


# Testing Instructions

collapse compute or simelar in projectoverview
navigate with the overview page and not the sidebar to a subservice
the section is expanded

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar behavior to automatically expand relevant sections when navigating to different routes, ensuring the active section is always visible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cobaltcore-dev/aurora-dashboard/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->