### PR TITLE
chore(core): make private packages as dev dependencies

### DIFF
--- a/.changeset/fix-private-deps.md
+++ b/.changeset/fix-private-deps.md
@@ -1,0 +1,8 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Fix package publishing issues found during initial consumer testing:
+
+- Removed `@cobaltcore-dev/policy-engine` and `@cobaltcore-dev/signal-openstack` from published `dependencies` — both are private packages bundled into the server build via tsup and must not be listed as npm dependencies
+- Added `permission_policies/` to the `files` array so OpenStack YAML files are included in the published package

--- a/packages/aurora/package.json
+++ b/packages/aurora/package.json
@@ -12,9 +12,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist", "permission_policies"],
   "publishConfig": {
     "access": "public"
   },
@@ -57,8 +55,6 @@
     "@aws-sdk/client-s3": "^3.1042.0",
     "@aws-sdk/lib-storage": "^3.1042.0",
     "@aws-sdk/s3-request-presigner": "^3.1042.0",
-    "@cobaltcore-dev/policy-engine": "workspace:*",
-    "@cobaltcore-dev/signal-openstack": "workspace:*",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/helmet": "^13.0.2",
@@ -89,6 +85,8 @@
   "devDependencies": {
     "@cloudoperators/juno-ui-components": "6.5.0",
     "@cobaltcore-dev/aurora-config": "workspace:*",
+    "@cobaltcore-dev/policy-engine": "workspace:*",
+    "@cobaltcore-dev/signal-openstack": "workspace:*",
     "@fastify/vite": "^8.4.1",
     "@lingui/cli": "^5.9.5",
     "@lingui/format-po": "^5.9.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,12 +131,6 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1042.0
         version: 3.1042.0
-      '@cobaltcore-dev/policy-engine':
-        specifier: workspace:*
-        version: link:../policy-engine
-      '@cobaltcore-dev/signal-openstack':
-        specifier: workspace:*
-        version: link:../signal-openstack
       '@fastify/cookie':
         specifier: ^11.0.2
         version: 11.0.2
@@ -231,6 +225,12 @@ importers:
       '@cobaltcore-dev/aurora-config':
         specifier: workspace:*
         version: link:../config
+      '@cobaltcore-dev/policy-engine':
+        specifier: workspace:*
+        version: link:../policy-engine
+      '@cobaltcore-dev/signal-openstack':
+        specifier: workspace:*
+        version: link:../signal-openstack
       '@fastify/vite':
         specifier: ^8.4.1
         version: 8.4.1(fastify@5.8.5)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))


### PR DESCRIPTION
## Summary

Fixes two issues discovered when installing `@cobaltcore-dev/aurora` in a consumer app for the first time.

## Changes Made

- Moved `@cobaltcore-dev/policy-engine` and `@cobaltcore-dev/signal-openstack` from `dependencies` to `devDependencies` both are private packages bundled into the server build via tsup and were causing `404` errors when consumers ran `pnpm i`
- Added `permission_policies/` to the `files` array in `package.json` as the server requires these OpenStack policy files at runtime and was failing to start without them in the published package.

## Related Issues

- Part of #810

## Testing Instructions

1. `pnpm pack` in `packages/aurora`
2. Install the tarball in a fresh consumer app
3. `pnpm install` should succeed without 404 errors
4. `pnpm dev` should start the server without "Policy file not found" error

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.