### PR TITLE
fix(aurora-portal): fix ceph tests

### DIFF
--- a/packages/aurora/src/server/Storage/cephProcedure.test.ts
+++ b/packages/aurora/src/server/Storage/cephProcedure.test.ts
@@ -115,6 +115,7 @@ const createMockContext = (options: MockContextOptions = {}) => {
     req: { headers: {} },
     validateSession: vi.fn().mockReturnValue(!shouldFailAuth),
     identityEndpoint: "http://identity.example.com/",
+    cephRegion: "ceph-objectstore-st1-test-region",
     imageMetadataExcludedProperties: [],
     createSession: vi.fn(),
     terminateSession: vi.fn(),
@@ -199,52 +200,9 @@ describe("cephProcedure", () => {
       })
     })
 
-    describe("region construction", () => {
-      beforeEach(() => {
-        vi.clearAllMocks()
-        mockResolveEC2Credential.mockResolvedValue({
-          credentialId: "cred-id",
-          access: TEST_ACCESS,
-          secret: TEST_SECRET,
-        })
-        mockCreateS3Client.mockReturnValue({ send: vi.fn() } as MockS3Client as S3Client)
-      })
-
-      it("constructs standard region for non-qa-de-1 regions", async () => {
-        process.env.CEPH_REGION = "ceph-objectstore-st1-eu-de-2"
-        const ctx = createMockContext({ endpoint: TEST_CEPH_ENDPOINT_NO_SWIFT, region: "eu-de-2" })
-        const caller = createCaller(ctx)
-
-        await caller.test.getClient({ project_id: TEST_PROJECT_ID })
-
-        expect(mockCreateS3Client).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.any(String),
-          expect.any(String),
-          "ceph-objectstore-st1-eu-de-2"
-        )
-      })
-
-      it("constructs QA region for qa-de-1 with ec prefix", async () => {
-        process.env.CEPH_REGION = "ceph-objectstore-ec-st1-qa-de-1"
-        const ctx = createMockContext({ endpoint: TEST_CEPH_ENDPOINT, region: "qa-de-1" })
-        const caller = createCaller(ctx)
-
-        await caller.test.getClient({ project_id: TEST_PROJECT_ID })
-
-        expect(mockCreateS3Client).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.any(String),
-          expect.any(String),
-          "ceph-objectstore-ec-st1-qa-de-1"
-        )
-      })
-    })
-
     describe("error handling", () => {
       beforeEach(() => {
         vi.clearAllMocks()
-        process.env.CEPH_REGION = "ceph-objectstore-ec-st1-qa-de-1"
         mockResolveEC2Credential.mockResolvedValue({
           credentialId: "cred-id",
           access: TEST_ACCESS,
@@ -287,23 +245,12 @@ describe("cephProcedure", () => {
           "Ceph service not found in catalog"
         )
       })
-
-      it("throws when CEPH_REGION environment variable is not set", async () => {
-        delete process.env.CEPH_REGION
-        const ctx = createMockContext()
-        const caller = createCaller(ctx)
-
-        await expect(caller.test.checkStatus({ project_id: TEST_PROJECT_ID })).rejects.toThrow(
-          "Ceph service not found in catalog"
-        )
-      })
     })
   })
 
   describe("cephCredentialMiddleware", () => {
     beforeEach(() => {
       vi.clearAllMocks()
-      process.env.CEPH_REGION = "ceph-objectstore-ec-st1-qa-de-1"
       mockCreateS3Client.mockReturnValue({ send: vi.fn() } as MockS3Client as S3Client)
     })
 
@@ -319,14 +266,13 @@ describe("cephProcedure", () => {
     })
 
     it("adds cephRegion to context", async () => {
-      process.env.CEPH_REGION = "ceph-objectstore-st1-eu-de-2"
       mockResolveEC2Credential.mockResolvedValue({ credentialId: "cred-id", access: TEST_ACCESS, secret: TEST_SECRET })
       const ctx = createMockContext({ region: "eu-de-2" })
       const caller = createCaller(ctx)
 
       const result = await caller.test.checkStatus({ project_id: TEST_PROJECT_ID })
 
-      expect(result.region).toBe("ceph-objectstore-st1-eu-de-2")
+      expect(result.region).toBe("ceph-objectstore-st1-test-region")
     })
 
     it("adds getCephClient factory to context", async () => {

--- a/packages/aurora/src/server/Storage/routers/ceph/containerRouter.test.ts
+++ b/packages/aurora/src/server/Storage/routers/ceph/containerRouter.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { TRPCError } from "@trpc/server"
-import { AuroraPortalContext } from "../../../context"
 import { containerRouter } from "./containerRouter"
 import { createCallerFactory, auroraRouter } from "../../../trpc"
+import { createMockContext, TEST_PROJECT_ID } from "./mockContext"
 
 // ============================================================================
 // MOCK AWS SDK S3 CLIENT
@@ -18,86 +18,8 @@ vi.mock("../../clients/s3Client", () => ({
 // MOCK DATA
 // ============================================================================
 
-const TEST_PROJECT_ID = "test-project-id"
-const TEST_USER_ID = "test-user-id"
-const TEST_ACCESS = "AKIAIOSFODNN7EXAMPLE"
-const TEST_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 const TEST_BUCKET_NAME = "my-test-bucket"
 const TEST_CREATION_DATE = new Date("2024-01-15T10:00:00Z")
-
-// ============================================================================
-// MOCK CONTEXT
-// ============================================================================
-
-const createMockContext = (shouldFailAuth = false, hasCredentials = true) => {
-  const credBlob = JSON.stringify({ access: TEST_ACCESS, secret: TEST_SECRET })
-  const mockIdentity = {
-    get: vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({
-        credentials: hasCredentials
-          ? [{ id: "cred-id", type: "ec2", project_id: TEST_PROJECT_ID, user_id: TEST_USER_ID, blob: credBlob }]
-          : [],
-      }),
-    }),
-    availableEndpoints: vi.fn().mockReturnValue([]),
-  }
-
-  const mockCephService = {
-    getEndpoint: () => "https://test-ceph.example.com",
-    availableEndpoints: () => [
-      {
-        region: "test-region",
-        url: "https://test-ceph.example.com",
-        interface: "public",
-        id: "test-id",
-        region_id: "test-region",
-      },
-    ],
-  }
-
-  const mockToken = {
-    tokenData: {
-      project: { id: TEST_PROJECT_ID },
-      user: {
-        id: TEST_USER_ID,
-        domain: { id: "default", name: "Default" },
-        name: "test-user",
-        password_expires_at: "",
-      },
-      catalog: [
-        {
-          type: "ceph",
-          name: "ceph",
-          endpoints: [{ region: "test-region", url: "https://test-ceph.example.com" }],
-        },
-      ],
-      expires_at: "",
-      issued_at: "",
-      methods: [],
-      roles: [],
-    },
-  }
-
-  const mockOpenstack = {
-    service: (serviceName: string) => {
-      if (serviceName === "ceph") return mockCephService
-      return mockIdentity
-    },
-    getToken: vi.fn().mockReturnValue(mockToken),
-  }
-
-  return {
-    req: { headers: {} },
-    validateSession: vi.fn().mockReturnValue(!shouldFailAuth),
-    identityEndpoint: "http://identity.example.com/",
-    imageMetadataExcludedProperties: [],
-    createSession: vi.fn(),
-    terminateSession: vi.fn(),
-    openstack: mockOpenstack,
-    rescopeSession: vi.fn().mockResolvedValue(mockOpenstack),
-  } as unknown as AuroraPortalContext
-}
 
 const createCaller = createCallerFactory(auroraRouter({ storage: { ceph: { containers: containerRouter } } }))
 
@@ -108,7 +30,6 @@ const createCaller = createCallerFactory(auroraRouter({ storage: { ceph: { conta
 describe("buckets.list", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    process.env.CEPH_REGION = "ceph-objectstore-st1-test-region"
     // First call returns list of buckets
     mockSend.mockResolvedValueOnce({
       Buckets: [{ Name: TEST_BUCKET_NAME, CreationDate: TEST_CREATION_DATE }],
@@ -162,7 +83,7 @@ describe("buckets.list", () => {
   })
 
   it("throws UNAUTHORIZED when session is invalid", async () => {
-    const ctx = createMockContext(true)
+    const ctx = createMockContext({ shouldFailAuth: true })
     const caller = createCaller(ctx)
 
     await expect(caller.storage.ceph.containers.list({ project_id: TEST_PROJECT_ID })).rejects.toThrow(
@@ -171,7 +92,7 @@ describe("buckets.list", () => {
   })
 
   it("throws FORBIDDEN with NO_CEPH_CREDENTIALS when no EC2 credentials exist", async () => {
-    const ctx = createMockContext(false, false)
+    const ctx = createMockContext({ hasCredentials: false })
     const caller = createCaller(ctx)
 
     await expect(caller.storage.ceph.containers.list({ project_id: TEST_PROJECT_ID })).rejects.toThrow(

--- a/packages/aurora/src/server/Storage/routers/ceph/ec2CredentialRouter.test.ts
+++ b/packages/aurora/src/server/Storage/routers/ceph/ec2CredentialRouter.test.ts
@@ -1,18 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { TRPCError } from "@trpc/server"
-import { AuroraPortalContext } from "../../../context"
 import { ec2CredentialRouter } from "./ec2CredentialRouter"
 import { createCallerFactory, auroraRouter } from "../../../trpc"
+import {
+  createMockContext as createBaseMockContext,
+  TEST_PROJECT_ID,
+  TEST_USER_ID,
+  TEST_ACCESS,
+  TEST_SECRET,
+} from "./mockContext"
 
 // ============================================================================
 // MOCK DATA
 // ============================================================================
 
-const TEST_PROJECT_ID = "test-project-id"
-const TEST_USER_ID = "test-user-id"
 const TEST_CREDENTIAL_ID = "cred-abc-123"
-const TEST_ACCESS = "AKIAIOSFODNN7EXAMPLE"
-const TEST_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 
 const mockBlob = JSON.stringify({ access: TEST_ACCESS, secret: TEST_SECRET })
 
@@ -29,54 +31,20 @@ const rawCredential = {
 // ============================================================================
 
 const createMockContext = (shouldFailAuth = false) => {
-  const mockIdentity = {
-    get: vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ credentials: [rawCredential] }),
-    }),
-    post: vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ credential: rawCredential }),
-    }),
-    del: vi.fn().mockResolvedValue({ ok: true, status: 204 }),
-    availableEndpoints: vi.fn().mockReturnValue([]),
-  }
+  const ctx = createBaseMockContext({ shouldFailAuth })
 
-  const mockToken = {
-    tokenData: {
-      project: { id: TEST_PROJECT_ID },
-      user: {
-        id: TEST_USER_ID,
-        domain: { id: "default", name: "Default" },
-        name: "test-user",
-        password_expires_at: "",
-      },
-      expires_at: "",
-      issued_at: "",
-      methods: [],
-      roles: [],
-    },
-  }
+  // Override mockIdentity with ec2Credential-specific methods
+  ctx.mockIdentity.get = vi.fn().mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue({ credentials: [rawCredential] }),
+  })
+  ctx.mockIdentity.post = vi.fn().mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue({ credential: rawCredential }),
+  })
+  ctx.mockIdentity.del = vi.fn().mockResolvedValue({ ok: true, status: 204 })
 
-  const mockOpenstack = {
-    service: vi.fn().mockReturnValue(mockIdentity),
-    getToken: vi.fn().mockReturnValue(mockToken),
-  }
-
-  return {
-    req: { headers: {} },
-    validateSession: vi.fn().mockReturnValue(!shouldFailAuth),
-    identityEndpoint: "http://identity.example.com/",
-    imageMetadataExcludedProperties: [],
-    createSession: vi.fn(),
-    terminateSession: vi.fn(),
-    openstack: mockOpenstack,
-    rescopeSession: vi.fn().mockResolvedValue({
-      service: vi.fn().mockReturnValue(mockIdentity),
-      getToken: vi.fn().mockReturnValue(mockToken),
-    }),
-    mockIdentity,
-  } as unknown as AuroraPortalContext & { mockIdentity: typeof mockIdentity }
+  return ctx
 }
 
 const createCaller = createCallerFactory(auroraRouter({ storage: { s3: { ec2Credentials: ec2CredentialRouter } } }))

--- a/packages/aurora/src/server/Storage/routers/ceph/mockContext.ts
+++ b/packages/aurora/src/server/Storage/routers/ceph/mockContext.ts
@@ -1,0 +1,116 @@
+import { vi } from "vitest"
+import type { AuroraPortalContext } from "../../../context"
+
+// ============================================================================
+// MOCK DATA
+// ============================================================================
+
+export const TEST_PROJECT_ID = "test-project-id"
+export const TEST_USER_ID = "test-user-id"
+export const TEST_ACCESS = "AKIAIOSFODNN7EXAMPLE"
+export const TEST_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+export const TEST_CEPH_REGION = "ceph-objectstore-st1-test-region"
+
+// ============================================================================
+// MOCK CONTEXT FACTORY
+// ============================================================================
+
+interface MockContextOptions {
+  shouldFailAuth?: boolean
+  hasCredentials?: boolean
+  endpoint?: string
+  region?: string
+}
+
+export const createMockContext = (options: MockContextOptions = {}) => {
+  const {
+    shouldFailAuth = false,
+    hasCredentials = true,
+    endpoint = "https://test-ceph.example.com",
+    region = "test-region",
+  } = options
+
+  const credBlob = JSON.stringify({ access: TEST_ACCESS, secret: TEST_SECRET })
+
+  const mockIdentity = {
+    get: vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        credentials: hasCredentials
+          ? [{ id: "cred-id", type: "ec2", project_id: TEST_PROJECT_ID, user_id: TEST_USER_ID, blob: credBlob }]
+          : [],
+      }),
+    }),
+    post: vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        credential: {
+          id: "cred-id",
+          type: "ec2",
+          project_id: TEST_PROJECT_ID,
+          user_id: TEST_USER_ID,
+          blob: credBlob,
+        },
+      }),
+    }),
+    del: vi.fn().mockResolvedValue({ ok: true, status: 204 }),
+    availableEndpoints: vi.fn().mockReturnValue([]),
+  }
+
+  const mockCephService = {
+    getEndpoint: () => endpoint,
+    availableEndpoints: () => [
+      {
+        region,
+        url: endpoint,
+        interface: "public",
+        id: "test-id",
+        region_id: region,
+      },
+    ],
+  }
+
+  const mockToken = {
+    tokenData: {
+      project: { id: TEST_PROJECT_ID },
+      user: {
+        id: TEST_USER_ID,
+        domain: { id: "default", name: "Default" },
+        name: "test-user",
+        password_expires_at: "",
+      },
+      catalog: [
+        {
+          type: "ceph",
+          name: "ceph",
+          endpoints: [{ region, url: endpoint }],
+        },
+      ],
+      expires_at: "",
+      issued_at: "",
+      methods: [],
+      roles: [],
+    },
+  }
+
+  const mockOpenstack = {
+    service: (serviceName: string) => {
+      if (serviceName === "ceph") return mockCephService
+      return mockIdentity
+    },
+    getToken: vi.fn().mockReturnValue(mockToken),
+  }
+
+  return {
+    req: { headers: {} },
+    validateSession: vi.fn().mockReturnValue(!shouldFailAuth),
+    identityEndpoint: "http://identity.example.com/",
+    cephRegion: TEST_CEPH_REGION,
+    imageMetadataExcludedProperties: [],
+    createSession: vi.fn(),
+    terminateSession: vi.fn(),
+    openstack: mockOpenstack,
+    rescopeSession: vi.fn().mockResolvedValue(mockOpenstack),
+    mockIdentity,
+  } as unknown as AuroraPortalContext & { mockIdentity: typeof mockIdentity }
+}

--- a/packages/aurora/src/server/Storage/routers/ceph/objectRouter.test.ts
+++ b/packages/aurora/src/server/Storage/routers/ceph/objectRouter.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { TRPCError } from "@trpc/server"
-import { AuroraPortalContext } from "../../../context"
 import { objectRouter } from "./objectRouter"
 import { createCallerFactory, auroraRouter } from "../../../trpc"
+import { createMockContext, TEST_PROJECT_ID } from "./mockContext"
 
 // ============================================================================
 // MOCK AWS SDK S3 CLIENT
@@ -18,88 +18,10 @@ vi.mock("../../clients/s3Client", () => ({
 // MOCK DATA
 // ============================================================================
 
-const TEST_PROJECT_ID = "test-project-id"
-const TEST_USER_ID = "test-user-id"
-const TEST_ACCESS = "AKIAIOSFODNN7EXAMPLE"
-const TEST_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 const TEST_BUCKET_NAME = "my-test-bucket"
 const TEST_OBJECT_KEY = "photos/2024/image.jpg"
 const TEST_FOLDER_PREFIX = "photos/2024/"
 const TEST_LAST_MODIFIED = new Date("2024-01-15T10:00:00Z")
-
-// ============================================================================
-// MOCK CONTEXT
-// ============================================================================
-
-const createMockContext = (shouldFailAuth = false, hasCredentials = true) => {
-  const credBlob = JSON.stringify({ access: TEST_ACCESS, secret: TEST_SECRET })
-  const mockIdentity = {
-    get: vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({
-        credentials: hasCredentials
-          ? [{ id: "cred-id", type: "ec2", project_id: TEST_PROJECT_ID, user_id: TEST_USER_ID, blob: credBlob }]
-          : [],
-      }),
-    }),
-    availableEndpoints: vi.fn().mockReturnValue([]),
-  }
-
-  const mockCephService = {
-    getEndpoint: () => "https://test-ceph.example.com",
-    availableEndpoints: () => [
-      {
-        region: "test-region",
-        url: "https://test-ceph.example.com",
-        interface: "public",
-        id: "test-id",
-        region_id: "test-region",
-      },
-    ],
-  }
-
-  const mockToken = {
-    tokenData: {
-      project: { id: TEST_PROJECT_ID },
-      user: {
-        id: TEST_USER_ID,
-        domain: { id: "default", name: "Default" },
-        name: "test-user",
-        password_expires_at: "",
-      },
-      catalog: [
-        {
-          type: "ceph",
-          name: "ceph",
-          endpoints: [{ region: "test-region", url: "https://test-ceph.example.com" }],
-        },
-      ],
-      expires_at: "",
-      issued_at: "",
-      methods: [],
-      roles: [],
-    },
-  }
-
-  const mockOpenstack = {
-    service: (serviceName: string) => {
-      if (serviceName === "ceph") return mockCephService
-      return mockIdentity
-    },
-    getToken: vi.fn().mockReturnValue(mockToken),
-  }
-
-  return {
-    req: { headers: {} },
-    validateSession: vi.fn().mockReturnValue(!shouldFailAuth),
-    identityEndpoint: "http://identity.example.com/",
-    imageMetadataExcludedProperties: [],
-    createSession: vi.fn(),
-    terminateSession: vi.fn(),
-    openstack: mockOpenstack,
-    rescopeSession: vi.fn().mockResolvedValue(mockOpenstack),
-  } as unknown as AuroraPortalContext
-}
 
 const createCaller = createCallerFactory(auroraRouter({ storage: { ceph: { objects: objectRouter } } }))
 
@@ -110,7 +32,6 @@ const createCaller = createCallerFactory(auroraRouter({ storage: { ceph: { objec
 describe("objects.list", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    process.env.CEPH_REGION = "ceph-objectstore-st1-test-region"
   })
 
   it("returns list of objects and folders", async () => {
@@ -252,7 +173,7 @@ describe("objects.list", () => {
   })
 
   it("throws UNAUTHORIZED when session is invalid", async () => {
-    const ctx = createMockContext(true)
+    const ctx = createMockContext({ shouldFailAuth: true })
     const caller = createCaller(ctx)
 
     await expect(
@@ -394,7 +315,7 @@ describe("objects.getDetails", () => {
   })
 
   it("throws UNAUTHORIZED when session is invalid", async () => {
-    const ctx = createMockContext(true)
+    const ctx = createMockContext({ shouldFailAuth: true })
     const caller = createCaller(ctx)
 
     await expect(

--- a/packages/aurora/src/server/Storage/routers/ceph/versioningRouter.test.ts
+++ b/packages/aurora/src/server/Storage/routers/ceph/versioningRouter.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { TRPCError } from "@trpc/server"
-import { AuroraPortalContext } from "../../../context"
 import { versioningRouter } from "./versioningRouter"
 import { createCallerFactory, auroraRouter } from "../../../trpc"
+import { createMockContext, TEST_PROJECT_ID } from "./mockContext"
 
 // ============================================================================
 // MOCK AWS SDK S3 CLIENT
@@ -18,84 +18,10 @@ vi.mock("../../clients/s3Client", () => ({
 // MOCK DATA
 // ============================================================================
 
-const TEST_PROJECT_ID = "test-project-id"
-const TEST_USER_ID = "test-user-id"
-const TEST_ACCESS = "AKIAIOSFODNN7EXAMPLE"
-const TEST_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 const TEST_BUCKET_NAME = "my-test-bucket"
 const TEST_OBJECT_KEY = "my-object.txt"
 const TEST_VERSION_ID = "version-123"
 const TEST_DATE = new Date("2024-01-15T10:00:00Z")
-
-// ============================================================================
-// MOCK CONTEXT
-// ============================================================================
-
-const createMockContext = (hasCredentials = true) => {
-  const credBlob = JSON.stringify({ access: TEST_ACCESS, secret: TEST_SECRET })
-  const mockIdentity = {
-    get: vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({
-        credentials: hasCredentials
-          ? [{ id: "cred-id", type: "ec2", project_id: TEST_PROJECT_ID, user_id: TEST_USER_ID, blob: credBlob }]
-          : [],
-      }),
-    }),
-    availableEndpoints: vi.fn().mockReturnValue([]),
-  }
-
-  const mockCephService = {
-    getEndpoint: () => "https://test-ceph.example.com",
-    availableEndpoints: () => [
-      {
-        region: "test-region",
-        url: "https://test-ceph.example.com",
-        interface: "public",
-        id: "test-id",
-        region_id: "test-region",
-      },
-    ],
-  }
-
-  const mockToken = {
-    tokenData: {
-      project: { id: TEST_PROJECT_ID },
-      user: {
-        id: TEST_USER_ID,
-        domain: { id: "default", name: "Default" },
-        name: "test-user",
-        password_expires_at: "",
-      },
-      catalog: [
-        {
-          type: "ceph",
-          name: "ceph",
-          endpoints: [{ region: "test-region", url: "https://test-ceph.example.com" }],
-        },
-      ],
-      expires_at: "",
-      issued_at: "",
-      methods: [],
-      roles: [],
-    },
-  }
-
-  const mockOpenstack = {
-    service: vi.fn().mockReturnValue(mockCephService),
-    getService: vi.fn().mockReturnValue(mockCephService),
-    identity: mockIdentity,
-  }
-
-  return {
-    openstack: mockOpenstack,
-    token: mockToken,
-    cephRegion: "test-region",
-    user: mockToken.tokenData.user,
-    project: mockToken.tokenData.project,
-    policies: [],
-  } as unknown as AuroraPortalContext
-}
 
 // ============================================================================
 // TESTS
@@ -139,7 +65,7 @@ describe("versioningRouter", () => {
     })
 
     it("should throw FORBIDDEN when no credentials", async () => {
-      const ctx = createMockContext(false)
+      const ctx = createMockContext({ hasCredentials: false })
       const callerNoAuth = createCaller(ctx)
 
       await expect(
@@ -179,7 +105,7 @@ describe("versioningRouter", () => {
     })
 
     it("should throw FORBIDDEN when no credentials", async () => {
-      const ctx = createMockContext(false)
+      const ctx = createMockContext({ hasCredentials: false })
       const callerNoAuth = createCaller(ctx)
 
       await expect(
@@ -319,7 +245,7 @@ describe("versioningRouter", () => {
     })
 
     it("should throw FORBIDDEN when no credentials", async () => {
-      const ctx = createMockContext(false)
+      const ctx = createMockContext({ hasCredentials: false })
       const callerNoAuth = createCaller(ctx)
 
       await expect(
@@ -366,7 +292,7 @@ describe("versioningRouter", () => {
     })
 
     it("should throw FORBIDDEN when no credentials", async () => {
-      const ctx = createMockContext(false)
+      const ctx = createMockContext({ hasCredentials: false })
       const callerNoAuth = createCaller(ctx)
 
       await expect(

--- a/packages/aurora/vitest.config.ts
+++ b/packages/aurora/vitest.config.ts
@@ -19,6 +19,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
-    exclude: ["src/server/**/*.test.ts", "node_modules", "dist"],
+    exclude: ["node_modules", "dist"],
   },
 })


### PR DESCRIPTION
## Fix server tests and enable individual test execution

  ### Problem
  Server tests were excluded from the test suite (`src/server/**/*.test.ts` in `vitest.config.ts` exclude), making it impossible to run them individually.
  When the exclude was removed, all Ceph tests failed with `cephRegion is required` errors.

  ### Solution

  **1. Created shared mock context** (`src/server/Storage/routers/ceph/mockContext.ts`)
  - Centralized mock setup for all Ceph router tests
  - Exports common test constants (`TEST_PROJECT_ID`, `TEST_USER_ID`, `TEST_ACCESS`, `TEST_SECRET`, `TEST_CEPH_REGION`)
  - Hardcoded `cephRegion: "ceph-objectstore-st1-test-region"` instead of relying on environment variables

  **2. Refactored all Ceph tests to use shared mock**
  - Updated `containerRouter.test.ts`, `objectRouter.test.ts`, `versioningRouter.test.ts` to import from shared mock
  - `ec2CredentialRouter.test.ts` extends the shared mock with credential-specific methods
  - Removed all references to `process.env.CEPH_REGION` from tests

  **3. Cleaned up `cephProcedure.test.ts`**
  - Removed tests that verified `process.env.CEPH_REGION` behavior
  - Removed tests for region construction from environment variables
  - Hardcoded `cephRegion` in mock context

  **4. Updated vitest config**
  - Removed `src/server/**/*.test.ts` from exclude list
  - Server tests now run with the rest of the suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure with centralized mock context factory for better code reuse and maintainability.
  * Updated test configuration to properly execute server-side tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->