### PR TITLE
fix(portal): image tabs are now in action bar

### DIFF
--- a/.changeset/good-sheep-work.md
+++ b/.changeset/good-sheep-work.md
@@ -2,4 +2,4 @@
 "@cobaltcore-dev/aurora": patch
 ---
 
-Image tabs are now in the actionbar
+Image tabs are now in the action bar.

--- a/.changeset/good-sheep-work.md
+++ b/.changeset/good-sheep-work.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Image tabs are now in the actionbar

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/List.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/List.tsx
@@ -212,18 +212,14 @@ function ImagesContent({
 
   return (
     <>
-      {/* Tab navigation for member status */}
-      <div className="w-full">
+      {/* Zone 1 — tabs + sort + create / more actions, no background */}
+      <Stack distribution="between" alignment="center" gap="2" className="pb-2">
         <TabNavigation activeItem={memberStatusView} onActiveItemChange={memberStatusTabs.onActiveItemChange}>
           {memberStatusTabs.items.map((item) => (
             <TabNavigationItem key={item.value} label={item.label} value={item.value} />
           ))}
         </TabNavigation>
-      </div>
-
-      {/* Zone 1 — sort + create / more actions, no background */}
-      <Stack distribution="end" alignment="center" gap="2" className="pb-2">
-        <Stack gap="0.5">
+        <Stack gap="0.5" alignment="center">
           <SortInput
             options={sortSettings.options}
             sortBy={sortSettings.sortBy}
@@ -233,8 +229,6 @@ function ImagesContent({
             }
             onSortDirectionChange={(dir) => handleSortChange({ ...sortSettings, sortDirection: dir })}
           />
-        </Stack>
-        <Stack gap="0.5">
           {permissions.canCreate && (
             <Button onClick={() => setCreateModalOpen(true)} variant="primary">
               <Trans>Create Image</Trans>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/List.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/List.tsx
@@ -213,7 +213,7 @@ function ImagesContent({
   return (
     <>
       {/* Zone 1 — tabs + sort + create / more actions, no background */}
-      <Stack distribution="between" alignment="center" gap="2" className="pb-2">
+      <Stack distribution="between" alignment="center" gap="2">
         <TabNavigation activeItem={memberStatusView} onActiveItemChange={memberStatusTabs.onActiveItemChange}>
           {memberStatusTabs.items.map((item) => (
             <TabNavigationItem key={item.value} label={item.label} value={item.value} />


### PR DESCRIPTION
# Summary

Tabs of Images are now in Actionbar

# Screenshots (if applicable)

<img width="1467" height="201" alt="Bildschirmfoto 2026-06-10 um 10 04 52" src="https://github.com/user-attachments/assets/ed80f8fc-0e3c-4dbb-9080-1d307df05a2c" />

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image tabs moved into the action bar for a cleaner header layout and improved navigation.
  * Header controls (tabs, sort, create) now align in a single row for more consistent spacing and easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->