### PR TITLE
refactor(portal): again new project view styles

### DIFF
--- a/.changeset/sharp-peaches-check.md
+++ b/.changeset/sharp-peaches-check.md
@@ -1,6 +1,5 @@
 ---
-"@cobaltcore-dev/aurora": minor
-"@cobaltcore-dev/dashboard": minor
+"@cobaltcore-dev/aurora": patch
 ---
 
 New styling for project overview and new playwright tests

--- a/.changeset/sharp-peaches-check.md
+++ b/.changeset/sharp-peaches-check.md
@@ -3,4 +3,4 @@
 "@cobaltcore-dev/dashboard": minor
 ---
 
-New styling for project overview and new playwrite tests
+New styling for project overview and new playwright tests

--- a/.changeset/sharp-peaches-check.md
+++ b/.changeset/sharp-peaches-check.md
@@ -1,0 +1,6 @@
+---
+"@cobaltcore-dev/aurora": minor
+"@cobaltcore-dev/dashboard": minor
+---
+
+New styling for project overview and new playwrite tests

--- a/apps/dashboard/e2e/ui/project-detail.spec.ts
+++ b/apps/dashboard/e2e/ui/project-detail.spec.ts
@@ -30,7 +30,7 @@ test.describe("Project Detail View", () => {
     const detailErrors = setupErrorTracking(page)
 
     // Click on test project
-    const projectHeading = page.locator("h5", { hasText: testProject })
+    const projectHeading = page.locator("p", { hasText: testProject }).first()
     await projectHeading.click()
 
     // Wait for project detail page to load
@@ -73,7 +73,7 @@ test.describe("Project Detail View", () => {
     const detailErrors = setupErrorTracking(page)
 
     // Click on test project
-    const projectHeading = page.locator("h5", { hasText: testProject })
+    const projectHeading = page.locator("p", { hasText: testProject }).first()
     await projectHeading.click()
 
     // Wait for project detail page to load

--- a/apps/dashboard/e2e/ui/project-detail.spec.ts
+++ b/apps/dashboard/e2e/ui/project-detail.spec.ts
@@ -30,7 +30,7 @@ test.describe("Project Detail View", () => {
     const detailErrors = setupErrorTracking(page)
 
     // Click on test project
-    const projectHeading = page.locator("p", { hasText: testProject }).first()
+    const projectHeading = page.locator('[data-testid="project-name"]', { hasText: testProject })
     await projectHeading.click()
 
     // Wait for project detail page to load
@@ -73,7 +73,7 @@ test.describe("Project Detail View", () => {
     const detailErrors = setupErrorTracking(page)
 
     // Click on test project
-    const projectHeading = page.locator("p", { hasText: testProject }).first()
+    const projectHeading = page.locator('[data-testid="project-name"]', { hasText: testProject })
     await projectHeading.click()
 
     // Wait for project detail page to load

--- a/apps/dashboard/e2e/ui/project-navigation.spec.ts
+++ b/apps/dashboard/e2e/ui/project-navigation.spec.ts
@@ -30,7 +30,7 @@ test.describe("Project Navigation", () => {
     const detailErrors = setupErrorTracking(page)
 
     // Click on test project
-    const projectHeading = page.locator("p", { hasText: testProject }).first()
+    const projectHeading = page.locator('[data-testid="project-name"]', { hasText: testProject })
     await projectHeading.click()
 
     // Wait for project detail page to load
@@ -67,7 +67,7 @@ test.describe("Project Navigation", () => {
     const detailErrors = setupErrorTracking(page)
 
     // Click on test project
-    const projectHeading = page.locator("p", { hasText: testProject }).first()
+    const projectHeading = page.locator('[data-testid="project-name"]', { hasText: testProject })
     await projectHeading.click()
 
     // Wait for project detail page to load
@@ -104,7 +104,7 @@ test.describe("Project Navigation", () => {
     const detailErrors = setupErrorTracking(page)
 
     // Click on test project
-    const projectHeading = page.locator("p", { hasText: testProject }).first()
+    const projectHeading = page.locator('[data-testid="project-name"]', { hasText: testProject })
     await projectHeading.click()
 
     // Wait for project detail page to load
@@ -141,7 +141,7 @@ test.describe("Project Navigation", () => {
     const detailErrors = setupErrorTracking(page)
 
     // Click on test project
-    const projectHeading = page.locator("p", { hasText: testProject }).first()
+    const projectHeading = page.locator('[data-testid="project-name"]', { hasText: testProject })
     await projectHeading.click()
 
     // Wait for project detail page to load
@@ -178,7 +178,7 @@ test.describe("Project Navigation", () => {
     const detailErrors = setupErrorTracking(page)
 
     // Click on test project
-    const projectHeading = page.locator("p", { hasText: testProject }).first()
+    const projectHeading = page.locator('[data-testid="project-name"]', { hasText: testProject })
     await projectHeading.click()
 
     // Wait for project detail page to load

--- a/apps/dashboard/e2e/ui/project-navigation.spec.ts
+++ b/apps/dashboard/e2e/ui/project-navigation.spec.ts
@@ -30,7 +30,7 @@ test.describe("Project Navigation", () => {
     const detailErrors = setupErrorTracking(page)
 
     // Click on test project
-    const projectHeading = page.locator("h5", { hasText: testProject })
+    const projectHeading = page.locator("p", { hasText: testProject }).first()
     await projectHeading.click()
 
     // Wait for project detail page to load
@@ -67,7 +67,7 @@ test.describe("Project Navigation", () => {
     const detailErrors = setupErrorTracking(page)
 
     // Click on test project
-    const projectHeading = page.locator("h5", { hasText: testProject })
+    const projectHeading = page.locator("p", { hasText: testProject }).first()
     await projectHeading.click()
 
     // Wait for project detail page to load
@@ -104,7 +104,7 @@ test.describe("Project Navigation", () => {
     const detailErrors = setupErrorTracking(page)
 
     // Click on test project
-    const projectHeading = page.locator("h5", { hasText: testProject })
+    const projectHeading = page.locator("p", { hasText: testProject }).first()
     await projectHeading.click()
 
     // Wait for project detail page to load
@@ -141,7 +141,7 @@ test.describe("Project Navigation", () => {
     const detailErrors = setupErrorTracking(page)
 
     // Click on test project
-    const projectHeading = page.locator("h5", { hasText: testProject })
+    const projectHeading = page.locator("p", { hasText: testProject }).first()
     await projectHeading.click()
 
     // Wait for project detail page to load
@@ -178,7 +178,7 @@ test.describe("Project Navigation", () => {
     const detailErrors = setupErrorTracking(page)
 
     // Click on test project
-    const projectHeading = page.locator("h5", { hasText: testProject })
+    const projectHeading = page.locator("p", { hasText: testProject }).first()
     await projectHeading.click()
 
     // Wait for project detail page to load

--- a/apps/dashboard/e2e/ui/projects-overview.spec.ts
+++ b/apps/dashboard/e2e/ui/projects-overview.spec.ts
@@ -34,7 +34,7 @@ test.describe("Projects Overview Page", () => {
     await page.waitForTimeout(500)
 
     // Verify the test project is visible in results
-    const projectHeading = page.locator("h5", { hasText: testProject })
+    const projectHeading = page.locator("p", { hasText: testProject })
     await expect(projectHeading).toBeVisible()
   })
 
@@ -45,7 +45,7 @@ test.describe("Projects Overview Page", () => {
     await expectNoJavaScriptErrors(errors, page)
 
     // Without searching, verify test project is in the list
-    const projectHeading = page.locator("h5", { hasText: testProject })
+    const projectHeading = page.locator("p", { hasText: testProject })
 
     // Should be visible (might need to scroll)
     await expect(projectHeading).toBeVisible({ timeout: 5000 })

--- a/apps/dashboard/e2e/ui/projects-overview.spec.ts
+++ b/apps/dashboard/e2e/ui/projects-overview.spec.ts
@@ -34,7 +34,7 @@ test.describe("Projects Overview Page", () => {
     await page.waitForTimeout(500)
 
     // Verify the test project is visible in results
-    const projectHeading = page.locator("p", { hasText: testProject })
+    const projectHeading = page.locator('[data-testid="project-name"]', { hasText: testProject })
     await expect(projectHeading).toBeVisible()
   })
 
@@ -45,7 +45,7 @@ test.describe("Projects Overview Page", () => {
     await expectNoJavaScriptErrors(errors, page)
 
     // Without searching, verify test project is in the list
-    const projectHeading = page.locator("p", { hasText: testProject })
+    const projectHeading = page.locator('[data-testid="project-name"]', { hasText: testProject })
 
     // Should be visible (might need to scroll)
     await expect(projectHeading).toBeVisible({ timeout: 5000 })

--- a/packages/aurora/src/client/routes/_auth/projects/-components/ProjectCardView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/-components/ProjectCardView.tsx
@@ -22,7 +22,9 @@ export function ProjectCard({ project }: ProjectCardProps) {
         <p className="text-text-light text-xs leading-5 font-normal">
           {project.domain_name ?? project.domain_id ?? <Trans>Unknown domain</Trans>}
         </p>
-        <p className="text-text-high text-lg leading-7 font-bold">{project.name}</p>
+        <p data-testid="project-name" className="text-text-high text-lg leading-7 font-bold">
+          {project.name}
+        </p>
       </div>
       {project.description && (
         <p className="text-text-default line-clamp-2 text-base leading-6 font-normal">{project.description}</p>

--- a/packages/aurora/src/client/routes/_auth/projects/-components/ProjectCardView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/-components/ProjectCardView.tsx
@@ -19,12 +19,14 @@ export function ProjectCard({ project }: ProjectCardProps) {
       className="flex flex-col gap-4"
     >
       <div className="flex min-w-0 flex-col">
-        <span className="text-theme-light text-xs leading-6">
+        <p className="text-text-light text-xs leading-5 font-normal">
           {project.domain_name ?? project.domain_id ?? <Trans>Unknown domain</Trans>}
-        </span>
-        <h5>{project.name}</h5>
+        </p>
+        <p className="text-text-high text-lg leading-7 font-bold">{project.name}</p>
       </div>
-      {project.description && <p className="text-theme-default line-clamp-2">{project.description}</p>}
+      {project.description && (
+        <p className="text-text-default line-clamp-2 text-base leading-6 font-normal">{project.description}</p>
+      )}
     </Card>
   )
 }

--- a/packages/aurora/src/client/routes/_auth/projects/-components/ProjectCardView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/-components/ProjectCardView.tsx
@@ -27,7 +27,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
         </p>
       </div>
       {project.description && (
-        <p className="text-text-default line-clamp-2 text-base leading-6 font-normal">{project.description}</p>
+        <p className="text-theme-default line-clamp-2 text-base leading-6 font-normal">{project.description}</p>
       )}
     </Card>
   )

--- a/packages/aurora/src/client/routes/_auth/projects/-components/ProjectCardView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/-components/ProjectCardView.tsx
@@ -19,7 +19,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
       className="flex flex-col gap-4"
     >
       <div className="flex min-w-0 flex-col">
-        <p className="text-text-light text-xs leading-5 font-normal">
+        <p className="text-theme-light text-xs leading-5 font-normal">
           {project.domain_name ?? project.domain_id ?? <Trans>Unknown domain</Trans>}
         </p>
         <p data-testid="project-name" className="text-text-high text-lg leading-7 font-bold">

--- a/packages/aurora/src/client/routes/_auth/projects/-components/ProjectCardView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/-components/ProjectCardView.tsx
@@ -22,7 +22,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
         <p className="text-theme-light text-xs leading-5 font-normal">
           {project.domain_name ?? project.domain_id ?? <Trans>Unknown domain</Trans>}
         </p>
-        <p data-testid="project-name" className="text-text-high text-lg leading-7 font-bold">
+        <p data-testid="project-name" className="text-theme-high text-lg leading-7 font-bold">
           {project.name}
         </p>
       </div>


### PR DESCRIPTION
## Summary
Closes #926 

- Restyle `ProjectCard` component: replace `h5` + `span` with `p` elements using explicit Tailwind typography classes (`text-text-high`, `text-text-light`, `text-text-default`, font-weight, line-height)
- Fix Playwright selectors in `projects-overview.spec.ts` to match the new `p` element (was `h5`)
- Fix remaining Playwright selectors in `project-navigation.spec.ts` and `project-detail.spec.ts` that still targeted `h5` and caused all project-detail/navigation tests to time out

## Test plan

- [ ] Run `pnpm test:e2e` — all 14 tests pass
- [ ] Visually verify project cards on the projects overview page look correct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refreshed the project overview and project card presentation with a clearer visual hierarchy.
  * Updated the display of domain labels, project names, and optional descriptions using improved typography, spacing, and color/line-clamp styling for better readability.
  * Adjusted the underlying heading structure so the updated project metadata presentation is consistent across the overview experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->