### PR TITLE
fix(portal): respect DASHBOARD_COOKIE_NAME and cookie env vars from .env

### DIFF
--- a/.changeset/fix-cookie-name-config.md
+++ b/.changeset/fix-cookie-name-config.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Fix cookie name configuration not being respected from env var. `DASHBOARD_COOKIE_NAME`, `ENABLE_CROSS_DASHBOARD_COOKIE`, and `INSECURE_COOKIES` env vars are now correctly forwarded by the OSS consumer. The default cookie name is defined once in `SessionCookie` and exported as `DEFAULT_COOKIE_NAME` for use throughout the package.

--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -11,7 +11,12 @@ CEPH_S3_ENDPOINT="https://rgw.example.com"
 # For other Ceph deployments, use your custom region identifier
 CEPH_REGION="ceph-objectstore-ec-st1-qa-de-1"
 IMAGE_METADATA_EXCLUDED_PROPERTIES="name,tags,visibility,protected,min_disk,min_ram,id,status,size,checksum,created_at,updated_at,created-at,updated-at,disk_format,container_format,file,schema,locations,self,direct_url,owner,virtual_size,kernel_id,ramdisk_id,os_hash_algo,os_hash_value,os-hash-algo,os-hash-value,stores,owner_specified.openstack.md5,owner_specified.openstack.sha256,owner_specified.openstack.object"
-INSECURE_COOKIES=true
+# Override the session cookie name (default: "dashboard-session-auth")
+# DASHBOARD_COOKIE_NAME="dashboard-session-auth"
+# Enable cookies to be shared across subdomains (default: true)
+# ENABLE_CROSS_DASHBOARD_COOKIE=true
+# Disable the Secure flag on cookies — for HTTP-only local dev only, never in production (default: false)
+# INSECURE_COOKIES=true
 
 # E2E Test Environment Variables
 PLAYWRIGHT_BASE_URL="http://localhost:4001"

--- a/apps/dashboard/src/server/server.ts
+++ b/apps/dashboard/src/server/server.ts
@@ -23,7 +23,11 @@ createServer({
   proxyUrl: process.env.GLOBAL_AGENT_HTTP_PROXY,
   cephRegion: process.env.CEPH_REGION,
   imageMetadataExcludedProperties: process.env.IMAGE_METADATA_EXCLUDED_PROPERTIES,
-  insecureCookies: process.env.INSECURE_COOKIES === "true",
+  cookieName: process.env.DASHBOARD_COOKIE_NAME || undefined,
+  crossDomainCookie: process.env.ENABLE_CROSS_DASHBOARD_COOKIE
+    ? process.env.ENABLE_CROSS_DASHBOARD_COOKIE.toLowerCase() === "true"
+    : undefined,
+  insecureCookies: process.env.INSECURE_COOKIES ? process.env.INSECURE_COOKIES.toLowerCase() === "true" : undefined,
   policyDir,
 })
   .then((server) => server.listen({ host: "0.0.0.0", port: PORT }))

--- a/packages/aurora/src/server/sessionCookie.test.ts
+++ b/packages/aurora/src/server/sessionCookie.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { SessionCookie } from "./sessionCookie"
+import { SessionCookie, DEFAULT_COOKIE_NAME } from "./sessionCookie"
 import type { CreateFastifyContextOptions } from "@trpc/server/adapters/fastify"
 
-const DEFAULT_COOKIE_NAME = "dashboard-session-auth"
-
 describe("SessionCookie", () => {
+  const TEST_HOSTNAME = "aurora.region-1.example.com"
   let mockRes: CreateFastifyContextOptions["res"]
 
   beforeEach(() => {
@@ -20,17 +19,23 @@ describe("SessionCookie", () => {
     }) as CreateFastifyContextOptions["req"]
 
   describe("Cookie Name", () => {
-    it("should use default cookie name", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
+    it("should use default cookie name when none is provided", () => {
+      const mockReq = createMockReq(TEST_HOSTNAME)
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
       cookie.set("my-auth-token")
       expect(mockRes.setCookie).toHaveBeenCalledWith(DEFAULT_COOKIE_NAME, "my-auth-token", expect.any(Object))
+    })
+    it("should use provided cookie name", () => {
+      const mockReq = createMockReq(TEST_HOSTNAME)
+      const cookie = SessionCookie({ req: mockReq, res: mockRes, cookieName: "some_cookie" })
+      cookie.set("my-auth-token")
+      expect(mockRes.setCookie).toHaveBeenCalledWith("some_cookie", "my-auth-token", expect.any(Object))
     })
   })
 
   describe("Cookie Operations", () => {
     it("should set cookie with token", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
+      const mockReq = createMockReq(TEST_HOSTNAME)
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
       cookie.set("my-auth-token")
 
@@ -47,7 +52,7 @@ describe("SessionCookie", () => {
     })
 
     it("should not set cookie if content is null", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
+      const mockReq = createMockReq(TEST_HOSTNAME)
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
       cookie.set(null)
 
@@ -55,7 +60,7 @@ describe("SessionCookie", () => {
     })
 
     it("should not set cookie if content is undefined", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
+      const mockReq = createMockReq(TEST_HOSTNAME)
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
       cookie.set(undefined)
 
@@ -63,7 +68,7 @@ describe("SessionCookie", () => {
     })
 
     it("should get cookie value", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
+      const mockReq = createMockReq(TEST_HOSTNAME)
       mockReq.cookies[DEFAULT_COOKIE_NAME] = "existing-token"
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
 
@@ -71,14 +76,14 @@ describe("SessionCookie", () => {
     })
 
     it("should return undefined when cookie does not exist", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
+      const mockReq = createMockReq(TEST_HOSTNAME)
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
 
       expect(cookie.get()).toBeUndefined()
     })
 
     it("should delete cookie", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
+      const mockReq = createMockReq(TEST_HOSTNAME)
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
       cookie.del()
 
@@ -98,7 +103,7 @@ describe("SessionCookie", () => {
     })
 
     it("should support custom cookie name", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
+      const mockReq = createMockReq(TEST_HOSTNAME)
       const customName = "my-custom-cookie"
       const cookie = SessionCookie({ req: mockReq, res: mockRes, cookieName: customName })
 
@@ -108,7 +113,7 @@ describe("SessionCookie", () => {
     })
 
     it("should support custom expires option", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
+      const mockReq = createMockReq(TEST_HOSTNAME)
       const expiryDate = new Date("2026-12-31")
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
 
@@ -124,7 +129,7 @@ describe("SessionCookie", () => {
     })
 
     it("should use root path for cross-dashboard access", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
+      const mockReq = createMockReq(TEST_HOSTNAME)
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
       cookie.set("test-token")
 
@@ -140,7 +145,7 @@ describe("SessionCookie", () => {
 
   describe("Cookie Security", () => {
     it("should set httpOnly to true", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
+      const mockReq = createMockReq(TEST_HOSTNAME)
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
       cookie.set("test-token")
 
@@ -154,7 +159,7 @@ describe("SessionCookie", () => {
     })
 
     it("should set secure to true by default", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
+      const mockReq = createMockReq(TEST_HOSTNAME)
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
       cookie.set("test-token")
 
@@ -168,8 +173,13 @@ describe("SessionCookie", () => {
     })
 
     it("should set secure to false when insecureCookies=true", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
-      const cookie = SessionCookie({ req: mockReq, res: mockRes, insecureCookies: true })
+      const mockReq = createMockReq(TEST_HOSTNAME)
+      const cookie = SessionCookie({
+        req: mockReq,
+        res: mockRes,
+        cookieName: DEFAULT_COOKIE_NAME,
+        insecureCookies: true,
+      })
       cookie.set("test-token")
 
       expect(mockRes.setCookie).toHaveBeenCalledWith(
@@ -182,7 +192,7 @@ describe("SessionCookie", () => {
     })
 
     it("should set sameSite to strict", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
+      const mockReq = createMockReq(TEST_HOSTNAME)
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
       cookie.set("test-token")
 
@@ -198,7 +208,7 @@ describe("SessionCookie", () => {
 
   describe("Domain Extraction", () => {
     it("should set domain for Aurora dashboard hostname", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
+      const mockReq = createMockReq(TEST_HOSTNAME)
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
 
       cookie.set("test-token")
@@ -207,13 +217,13 @@ describe("SessionCookie", () => {
         DEFAULT_COOKIE_NAME,
         "test-token",
         expect.objectContaining({
-          domain: ".qa-de-1.cloud.sap",
+          domain: ".region-1.example.com",
         })
       )
     })
 
     it("should set domain for Elektra dashboard hostname", () => {
-      const mockReq = createMockReq("dashboard.qa-de-1.cloud.sap")
+      const mockReq = createMockReq("dashboard.region-1.example.com")
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
 
       cookie.set("test-token")
@@ -222,13 +232,13 @@ describe("SessionCookie", () => {
         DEFAULT_COOKIE_NAME,
         "test-token",
         expect.objectContaining({
-          domain: ".qa-de-1.cloud.sap",
+          domain: ".region-1.example.com",
         })
       )
     })
 
     it("should set domain for production hostnames", () => {
-      const mockReq = createMockReq("aurora.eu-de-1.cloud.sap")
+      const mockReq = createMockReq("aurora.region-2.example.com")
       const cookie = SessionCookie({ req: mockReq, res: mockRes })
 
       cookie.set("test-token")
@@ -237,7 +247,7 @@ describe("SessionCookie", () => {
         DEFAULT_COOKIE_NAME,
         "test-token",
         expect.objectContaining({
-          domain: ".eu-de-1.cloud.sap",
+          domain: ".region-2.example.com",
         })
       )
     })
@@ -288,8 +298,13 @@ describe("SessionCookie", () => {
     })
 
     it("should not set domain when crossDomainCookie=false", () => {
-      const mockReq = createMockReq("aurora.qa-de-1.cloud.sap")
-      const cookie = SessionCookie({ req: mockReq, res: mockRes, crossDomainCookie: false })
+      const mockReq = createMockReq(TEST_HOSTNAME)
+      const cookie = SessionCookie({
+        req: mockReq,
+        res: mockRes,
+        cookieName: DEFAULT_COOKIE_NAME,
+        crossDomainCookie: false,
+      })
 
       cookie.set("test-token")
 

--- a/packages/aurora/src/server/sessionCookie.ts
+++ b/packages/aurora/src/server/sessionCookie.ts
@@ -9,7 +9,7 @@ export interface SessionProps {
   res: FastifyReply
 }
 
-const DEFAULT_COOKIE_NAME = "dashboard-session-auth"
+export const DEFAULT_COOKIE_NAME = "dashboard-session-auth"
 
 function extractCookieDomain(hostname: string, crossDomainCookie: boolean): string | undefined {
   if (!crossDomainCookie) return undefined


### PR DESCRIPTION
## Summary

<img width="1512" height="600" alt="Screenshot 2026-06-22 at 12 44 41" src="https://github.com/user-attachments/assets/afe29f17-b3d6-4998-8dd6-70109b6b9353" />


- Fixes bug where `DASHBOARD_COOKIE_NAME` env var was silently ignored — the OSS consumer `apps/dashboard` never forwarded it to `createServer()`
- Wires up all three cookie env vars in the OSS consumer: `DASHBOARD_COOKIE_NAME`, `ENABLE_CROSS_DASHBOARD_COOKIE`, `INSECURE_COOKIES`
- Exports `DEFAULT_COOKIE_NAME` from `sessionCookie.ts` as the single source of truth for the default cookie name
- Adds guard against empty-string env vars (`|| undefined`) so they fall through to the library default
- Documents all three env vars in `.env.example` (commented out, with defaults noted)
- Adds missing test for default cookie name behavior when none is provided
- Removes internal SAP hostnames from test file, replaced with generic `example.com` equivalents

## Test plan

- [x] Run `pnpm test` — all tests pass
- [x] Run `pnpm typecheck` — no type errors
- [x] Set `DASHBOARD_COOKIE_NAME=my-custom-session` in `.env` and verify the BFF sets that cookie name on login
- [x] Leave `DASHBOARD_COOKIE_NAME` unset and verify the default `dashboard-session-auth` cookie name is used
- [x] Set `ENABLE_CROSS_DASHBOARD_COOKIE=true` and verify cross-subdomain cookie domain is set
- [x] Set `INSECURE_COOKIES=true` and verify the `Secure` flag is absent from the cookie

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cookie configuration from environment variables (session cookie name, cross-domain sharing, and insecure mode) is now correctly applied.

* **Documentation**
  * Added configuration guidance for optional cookie settings in the environment file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->