### PR TITLE
fix(metrics): resolve race condition in router analytics setup

### DIFF
--- a/.changeset/plenty-lizards-care.md
+++ b/.changeset/plenty-lizards-care.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Fixes a race condition where router analytics subscription was being set up before the `onTrackEvent` callback was available in the router context. This prevented analytics events from being tracked properly.

--- a/packages/aurora/src/client/App.tsx
+++ b/packages/aurora/src/client/App.tsx
@@ -39,13 +39,6 @@ const App = (props: AppProps) => {
 
   const [router] = useState(() => createAuroraRouter(trpcReact, trpcClient))
 
-  // Set up analytics tracking for router navigation
-  useEffect(() => {
-    if (props.onTrackEvent) {
-      return setupRouterAnalytics(router)
-    }
-  }, [router, props.onTrackEvent])
-
   const [currentTheme, setCurrentTheme] = useState<"theme-dark" | "theme-light">(props.theme ?? "theme-light")
 
   const [queryClient] = useState(
@@ -141,6 +134,14 @@ function AppInner({
     appName,
     onTrackEvent,
   }
+
+  // Set up analytics tracking for router navigation
+  // Must run AFTER RouterProvider processes the context, so use a separate effect
+  useEffect(() => {
+    if (onTrackEvent) {
+      return setupRouterAnalytics(router)
+    }
+  }, [router, onTrackEvent])
 
   return <RouterProvider router={router} context={routerContext} />
 }


### PR DESCRIPTION
# Summary

Fixes a race condition where router analytics subscription was being set up before the `onTrackEvent` callback was available in the router context. This prevented analytics events from being tracked properly.

# Changes Made

- Moved `setupRouterAnalytics` call from parent `App` component to `AppInner` component
- Added conditional check to only subscribe when `onTrackEvent` callback is provided
- Added comment explaining why the subscription must run after `RouterProvider` processes the context

# Related Issues

Addresses issue identified in PR review where `router.options.context.onTrackEvent` was `undefined` due to timing of context initialization.

# Testing Instructions

1. `pnpm i`
2. `pnpm run dev` (not preview, as preview uses production build)
3. Navigate between routes in the application
4. Check browser console for `[Analytics]` logs showing tracked navigation events (when onTrackEvent callback is provided in dashboard App.tsx)

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.