### PR TITLE
feat(metrics):  expose the res FastifyReply object in AuroraPortalContext

### DIFF
--- a/.changeset/chilly-guests-design.md
+++ b/.changeset/chilly-guests-design.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Expose the `res` (FastifyReply) object in `AuroraPortalContext` to allow consumer tRPC procedures to set response headers and cookies.

--- a/packages/aurora/src/server/Compute/routers/flavorRouter.test.ts
+++ b/packages/aurora/src/server/Compute/routers/flavorRouter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import type { FastifyRequest } from "fastify"
+import type { FastifyRequest, FastifyReply } from "fastify"
 import { flavorRouter } from "./flavorRouter"
 import { Flavor } from "../types/flavor"
 import { TRPCError } from "@trpc/server"
@@ -21,6 +21,7 @@ vi.mock("../helpers/flavorHelpers", () => ({
 
 const createMockContext = (shouldFailAuth = false, shouldFailRescope = false, shouldFailCompute = false) => ({
   req: { headers: {} } as FastifyRequest,
+  res: { setCookie: vi.fn() } as unknown as FastifyReply,
   signal: new AbortController().signal,
   validateSession: vi.fn().mockReturnValue(!shouldFailAuth),
   identityEndpoint: "http://identity.example.com/",

--- a/packages/aurora/src/server/context.ts
+++ b/packages/aurora/src/server/context.ts
@@ -1,5 +1,5 @@
 import type { CreateFastifyContextOptions } from "@trpc/server/adapters/fastify"
-import type { FastifyRequest } from "fastify"
+import type { FastifyRequest, FastifyReply } from "fastify"
 import { SignalOpenstackSession, SignalOpenstackSessionType } from "@cobaltcore-dev/signal-openstack"
 import { SessionCookie } from "./sessionCookie"
 import { AuthConfig } from "./Authentication/types/models"
@@ -57,6 +57,8 @@ export interface FormFieldData {
 
 export interface AuroraPortalContext extends AuroraContext {
   req: FastifyRequest
+  /** Fastify reply object for setting response headers/cookies */
+  res: FastifyReply
   /** Normalised identity endpoint (always ends with /) */
   identityEndpoint: string
   /** Ceph/S3 region from consumer config */
@@ -417,6 +419,7 @@ export async function createContext(
 
   return {
     req: opts.req,
+    res: opts.res,
     signal: abortController.signal,
     identityEndpoint: normalizedEndpoint,
     cephRegion: config.cephRegion,


### PR DESCRIPTION
Expose the `res` (FastifyReply) object in `AuroraPortalContext` to allow consumer tRPC procedures to set response headers and cookies.

# Changes Made

- Added `res: FastifyReply` to the `AuroraPortalContext` interface in `context.ts`
- Added `FastifyReply` import from "fastify" in `context.ts`
- Updated `createContext` to include `res: opts.res` in the returned context
- Updated related test files

# Related Issues

- Enables consumers to implement user behavior analytics with HttpOnly cookies

# Screenshots (if applicable)

N/A - Backend change only.

# Testing Instructions

1. `pnpm i`
2. `pnpm run test`
3. `pnpm run typecheck`

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to the HTTP response in portal context, enabling procedures to set response headers and cookies.
* **Bug Fixes**
  * Improved test coverage for cookie-related behavior to better validate response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->