### PR TITLE
feat(aurora): add badge support to ContentHeader

### DIFF
--- a/.changeset/badge-support-contentheader.md
+++ b/.changeset/badge-support-contentheader.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": minor
+---
+
+Add badge support to ContentHeader component. Badges can be passed via the `badges` prop and will display on the left side of the actions row below the divider. Also adds consistent mb-8 margin to the header element.

--- a/packages/aurora/src/client/components/ContentHeader/ContentHeader.tsx
+++ b/packages/aurora/src/client/components/ContentHeader/ContentHeader.tsx
@@ -11,9 +11,10 @@ interface ContentHeaderProps {
   projectId: string
   description?: string | null
   actions?: ReactNode
+  badges?: ReactNode
 }
 
-export function ContentHeader({ title, projectId, description, actions }: ContentHeaderProps) {
+export function ContentHeader({ title, projectId, description, actions, badges }: ContentHeaderProps) {
   const { slots } = useRouteContext({ strict: false })
   const matches = useMatches()
   const { provider } = useParams({ strict: false }) as { provider?: string }
@@ -30,7 +31,7 @@ export function ContentHeader({ title, projectId, description, actions }: Conten
   ) : null
 
   return (
-    <header>
+    <header className="mb-8">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <ContentHeading>{title}</ContentHeading>
@@ -45,7 +46,12 @@ export function ContentHeader({ title, projectId, description, actions }: Conten
       </div>
       {description && <p className="text-sm font-normal">{description}</p>}
       <Divider className="mt-4" />
-      {actions && <div className="mt-3 flex justify-end">{actions}</div>}
+      {(badges || actions) && (
+        <div className="mt-3 flex items-start justify-between">
+          <div className="flex items-center gap-2">{badges} </div>
+          {actions && <div className="flex gap-2">{actions}</div>}
+        </div>
+      )}
     </header>
   )
 }


### PR DESCRIPTION
Add badges prop to ContentHeader component that displays on the left side of the actions row (below the divider). Also add mb-8 margin to header for consistent spacing.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added badge support to content headers, allowing badges to appear alongside header actions.
  * Updated header spacing for a more consistent layout across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->