### PR TITLE
feat(aurora): add serviceBanner slot

### DIFF
--- a/.changeset/service-banner-slot.md
+++ b/.changeset/service-banner-slot.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": minor
+---
+
+Add `serviceBanner` slot — renders below the page title divider on service pages, receives `auroraContext.currentService`

--- a/packages/aurora/README.md
+++ b/packages/aurora/README.md
@@ -167,10 +167,11 @@ function MyFooter(_props: SlotProps) {
 | `login`                 | Replaces the default login form — use in OIDC environments                   | —                              | No                    |
 | `serviceBadge`          | Inline next to each service label in the side nav and project home cards     | `currentService` (service key) | No                    |
 | `servicePageActions`    | Beside the page title in the service page header                             | `currentService` (service key) | No                    |
+| `serviceBanner`         | Below the page title divider on every service page                           | `currentService` (service key) | No                    |
 | `projectsBanner`        | Below the "Projects" heading on the projects list page                       | —                              | No                    |
 | `projectOverviewBanner` | Below the project description on the project overview page (`/projects/:id`) | —                              | No                    |
 
-The `serviceBadge` and `servicePageActions` slots receive `auroraContext.currentService` — a string identifying which service is being rendered (e.g. `"images"`, `"ceph-containers"`). Return `null` from these slots to suppress rendering for specific services.
+The `serviceBadge`, `servicePageActions`, and `serviceBanner` slots receive `auroraContext.currentService` — a string identifying which service is being rendered (e.g. `"images"`, `"ceph-containers"`). Return `null` from these slots to suppress rendering for specific services.
 
 **Service key reference:** `"images"`, `"flavors"`, `"securitygroups"`, `"floatingips"`, `"containers"`, `"ceph-containers"`, `"pca"`
 

--- a/packages/aurora/src/client/AuroraApp.tsx
+++ b/packages/aurora/src/client/AuroraApp.tsx
@@ -30,6 +30,8 @@ export type Slots = {
   projectsBanner?: FC<SlotProps>
   /** Rendered below the project description on the project overview page (/projects/$projectId). Renders outside shadow DOM. */
   projectOverviewBanner?: FC<SlotProps>
+  /** Rendered below the page title divider on every service page. Receives `auroraContext.currentService`. Renders outside shadow DOM. */
+  serviceBanner?: FC<SlotProps>
 }
 
 /**

--- a/packages/aurora/src/client/components/ContentHeader/ContentHeader.tsx
+++ b/packages/aurora/src/client/components/ContentHeader/ContentHeader.tsx
@@ -30,6 +30,10 @@ export function ContentHeader({ title, projectId, description, actions, badges }
     <Slot component={slots.servicePageActions} useShadowDOM={false} currentService={currentService} />
   ) : null
 
+  const serviceBanner = slots?.serviceBanner ? (
+    <Slot component={slots.serviceBanner} useShadowDOM={false} currentService={currentService} />
+  ) : null
+
   return (
     <header className="mb-8">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
@@ -46,6 +50,7 @@ export function ContentHeader({ title, projectId, description, actions, badges }
       </div>
       {description && <p className="text-sm font-normal">{description}</p>}
       <Divider className="mt-4" />
+      {serviceBanner}
       {(badges || actions) && (
         <div className="mt-3 flex items-start justify-between">
           <div className="flex items-center gap-2">{badges} </div>

--- a/packages/aurora/src/client/components/ContentHeader/ContentHeader.tsx
+++ b/packages/aurora/src/client/components/ContentHeader/ContentHeader.tsx
@@ -26,13 +26,15 @@ export function ContentHeader({ title, projectId, description, actions, badges }
   // Distinguish them by the $provider param.
   const currentService = routeService === "containers" && provider === "ceph" ? "ceph-containers" : routeService
 
-  const slotActions = slots?.servicePageActions ? (
-    <Slot component={slots.servicePageActions} useShadowDOM={false} currentService={currentService} />
-  ) : null
+  const slotActions =
+    slots?.servicePageActions && currentService ? (
+      <Slot component={slots.servicePageActions} useShadowDOM={false} currentService={currentService} />
+    ) : null
 
-  const serviceBanner = slots?.serviceBanner ? (
-    <Slot component={slots.serviceBanner} useShadowDOM={false} currentService={currentService} />
-  ) : null
+  const serviceBanner =
+    slots?.serviceBanner && currentService ? (
+      <Slot component={slots.serviceBanner} useShadowDOM={false} currentService={currentService} />
+    ) : null
 
   return (
     <header className="mb-8">


### PR DESCRIPTION
# Summary

Add `serviceBanner` slot to `AuroraApp` that renders below the page title divider on every service page, receiving `auroraContext.currentService` so consumers can conditionally show content per service.

# Changes Made

- `AuroraApp.tsx` - added `serviceBanner` to `Slots` type with JSDoc
- `ContentHeader.tsx` - renders `serviceBanner` slot below the divider, passing `currentService`
- `README.md` - added `serviceBanner` to the slots table, updated `currentService` note
- `.changeset/service-banner-slot.md` - minor changeset

# Related Issues

- Issue: https://github.com/cobaltcore-dev/aurora-dashboard/issues/983

# Screenshots (if applicable)

<!-- n/a -->

# Testing Instructions

1. `pnpm i`
2. `pnpm run test`

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new service banner slot on service pages, shown below the page title divider.
  * The banner can use the current service context to display service-specific content.

* **Documentation**
  * Updated the README to include the new slot in the available slots list.
  * Clarified which service-related slots receive the current service context.

* **Chores**
  * Updated release notes to reflect a minor version bump.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->