### PR TITLE
feat(portal): combine domain/project in breadcrumb, correct margin in overview, juno 9.1.0

### DIFF
--- a/.changeset/juno-upgrade-and-margins.md
+++ b/.changeset/juno-upgrade-and-margins.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+chore(aurora): upgrade Juno UI components to 9.1.0 and fix margins in overview

--- a/.changeset/temp-changeset.md
+++ b/.changeset/temp-changeset.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Combine domain and project in breadcrumb (domain/project)

--- a/packages/aurora/package.json
+++ b/packages/aurora/package.json
@@ -85,7 +85,7 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
-    "@cloudoperators/juno-ui-components": "9.0.1",
+    "@cloudoperators/juno-ui-components": "9.1.0",
     "@cobaltcore-dev/aurora-config": "workspace:*",
     "@cobaltcore-dev/policy-engine": "workspace:*",
     "@cobaltcore-dev/signal-openstack": "workspace:*",

--- a/packages/aurora/src/client/components/ProjectView/ProjectInfoBox.test.tsx
+++ b/packages/aurora/src/client/components/ProjectView/ProjectInfoBox.test.tsx
@@ -48,31 +48,25 @@ describe("ProjectInfoBox", () => {
   })
 
   describe("Rendering", () => {
-    it("renders project name in breadcrumb", async () => {
+    it("renders combined domain/project in breadcrumb", async () => {
       render(<ProjectInfoBox projectInfo={defaultProjectInfo} />, { wrapper: Wrapper })
       await waitFor(() => {
-        expect(screen.getByText("My Project")).toBeInTheDocument()
+        expect(screen.getByText("my-domain.com/My Project")).toBeInTheDocument()
       })
     })
 
-    it("renders domain name in breadcrumb when available", async () => {
-      render(<ProjectInfoBox projectInfo={defaultProjectInfo} />, { wrapper: Wrapper })
-      await waitFor(() => {
-        expect(screen.getByText("my-domain.com")).toBeInTheDocument()
-      })
-    })
-
-    it("omits domain when not provided", async () => {
+    it("renders project name only when domain not provided", async () => {
       const props = { ...defaultProjectInfo, domain: undefined }
       render(<ProjectInfoBox projectInfo={props} />, { wrapper: Wrapper })
       await waitFor(() => {
+        expect(screen.getByText("My Project")).toBeInTheDocument()
         expect(screen.queryByText("my-domain.com")).not.toBeInTheDocument()
       })
     })
   })
 
   describe("Breadcrumbs — service list pages", () => {
-    it("renders domain > project > Images on images list", async () => {
+    it("renders domain/project > Images on images list", async () => {
       mockMatches = [
         { routeId: PROJECT_ROUTE_ID },
         {
@@ -90,8 +84,7 @@ describe("ProjectInfoBox", () => {
       render(<ProjectInfoBox projectInfo={defaultProjectInfo} />, { wrapper: Wrapper })
 
       await waitFor(() => {
-        expect(screen.getByText("my-domain.com")).toBeInTheDocument()
-        expect(screen.getByText("My Project")).toBeInTheDocument()
+        expect(screen.getByText("my-domain.com/My Project")).toBeInTheDocument()
         expect(screen.queryByText("Compute")).not.toBeInTheDocument()
         expect(screen.getByText("Images")).toBeInTheDocument()
       })

--- a/packages/aurora/src/client/components/ProjectView/ProjectInfoBox.tsx
+++ b/packages/aurora/src/client/components/ProjectView/ProjectInfoBox.tsx
@@ -44,10 +44,6 @@ export function ProjectInfoBox({ projectInfo }: ProjectInfoBoxProps) {
 
     items.push({ icon: "home", label: t`Home`, onClick: () => navigate({ to: "/projects" }) })
 
-    if (projectInfo.domain?.name) {
-      items.push({ label: projectInfo.domain.name })
-    }
-
     const projectMatches = matches.filter(
       (m) => m.routeId !== "/_auth/projects/$projectId" && m.routeId.startsWith("/_auth/projects/$projectId")
     )
@@ -55,13 +51,15 @@ export function ProjectInfoBox({ projectInfo }: ProjectInfoBoxProps) {
 
     const info = deepest ? (isRouteInfo(deepest.staticData) ? deepest.staticData : undefined) : undefined
 
+    const combinedLabel = projectInfo.domain?.name ? `${projectInfo.domain.name}/${projectInfo.name}` : projectInfo.name
+
     if (!deepest || !info) {
-      items.push({ label: projectInfo.name, active: true })
+      items.push({ label: combinedLabel, active: true })
       return items
     }
 
     items.push({
-      label: projectInfo.name,
+      label: combinedLabel,
       onClick: () => navigate({ to: "/projects/$projectId", params: { projectId } }),
     })
 

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/index.tsx
@@ -96,9 +96,13 @@ function RouteComponent() {
   }
 
   return (
-    <Stack direction="vertical" gap="6" className="pb-4">
+    <Stack direction="vertical">
       <ContentHeader title={crumbProject?.name ?? t`Project`} projectId={projectId} description={description} />
-      {slots?.projectOverviewBanner && <Slot component={slots.projectOverviewBanner} useShadowDOM={false} />}
+      {slots?.projectOverviewBanner && (
+        <div className="mb-6">
+          <Slot component={slots.projectOverviewBanner} useShadowDOM={false} />
+        </div>
+      )}
       {cards.length > 0 ? (
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
           {cards.map((card) => (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,8 +230,8 @@ importers:
         version: 4.3.6
     devDependencies:
       '@cloudoperators/juno-ui-components':
-        specifier: 9.0.1
-        version: 9.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sonner@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        specifier: 9.1.0
+        version: 9.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sonner@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@cobaltcore-dev/aurora-config':
         specifier: workspace:*
         version: link:../config
@@ -800,8 +800,8 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@cloudoperators/juno-ui-components@9.0.1':
-    resolution: {integrity: sha512-K3SuGyPDNG75r/1izrpmJlEmiaac1lyxnXuVZKDj6uF4jueeblxDgBqpzXQ29+JpI1/8lNE/r/OqKj5UN143AA==}
+  '@cloudoperators/juno-ui-components@9.1.0':
+    resolution: {integrity: sha512-WVSRkSGUyi4e9DlcBcF737qDjwU5iZtQm2SMI+PQNKJbv1sp9TlW+bo3QrVh30i/BByX4bo3B7bHJxl7TLRDCQ==}
     engines: {node: '>=20.19.0', pnpm: '>=8.0.0'}
     peerDependencies:
       react: ^19.1.0
@@ -6736,7 +6736,7 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@cloudoperators/juno-ui-components@9.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sonner@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+  '@cloudoperators/juno-ui-components@9.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sonner@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)


### PR DESCRIPTION
## Summary

Changes the breadcrumb display from `Home > Domain > Project` to `Home > Domain/Project` by combining the domain and project names into a single breadcrumb item with a forward slash separator. Update Juno. New margins around slot instead of gap

## Changes

- Modified `ProjectInfoBox.tsx` to combine domain and project names with `/` separator
- Removed the separate domain breadcrumb item
- The combined label is used both for the active state (project overview) and clickable state (sub-routes)
- Update Juno
- New margins around slot instead of gap

## Visual Impact

**Before:** `Home > ccadmin > demo`  
**After:** `Home > ccadmin/demo`

The domain is no longer a separate, non-clickable breadcrumb item, which streamlines the UI and makes the hierarchical relationship clearer.


# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated breadcrumb labels in project views so domain and project now appear together as `domain/project` when a domain is available.
  * Improved consistency in the home/breadcrumb trail by using the same combined label across the initial navigation entries.

* **Chores**
  * Added a patch-level changeset entry for the update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->