### PR TITLE
feat(portal): sort projects alphabetically by name

### DIFF
--- a/.changeset/strict-hands-check.md
+++ b/.changeset/strict-hands-check.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Sort projects alphabetically by name on the projects overview page

--- a/packages/aurora/src/client/routes/_auth/projects/-components/ProjectCardView.test.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/-components/ProjectCardView.test.tsx
@@ -126,4 +126,25 @@ describe("ProjectCardView", () => {
       { timeout: 1000 }
     )
   })
+
+  test("renders projects sorted alphabetically by name", async () => {
+    const unsortedProjects = [
+      { ...projects[0], id: "3", name: "Zebra Project" },
+      { ...projects[0], id: "1", name: "Alpha Project" },
+      { ...projects[0], id: "2", name: "Beta Project" },
+    ]
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <ProjectCardView projects={unsortedProjects} />
+      </I18nProvider>
+    )
+
+    await waitFor(() => {
+      const projectNames = screen.getAllByTestId("project-name")
+      expect(projectNames[0].textContent).toBe("Alpha Project")
+      expect(projectNames[1].textContent).toBe("Beta Project")
+      expect(projectNames[2].textContent).toBe("Zebra Project")
+    })
+  })
 })

--- a/packages/aurora/src/client/routes/_auth/projects/-components/ProjectCardView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/-components/ProjectCardView.tsx
@@ -38,7 +38,9 @@ export function ProjectCardView({ projects }: ProjectCardViewProps) {
     <div className="w-full">
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
         {projects?.length ? (
-          projects.map((project) => <ProjectCard key={project.id} project={project} />)
+          [...projects]
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((project) => <ProjectCard key={project.id} project={project} />)
         ) : (
           <p className="text-center">
             <Trans>No projects available.</Trans>


### PR DESCRIPTION
## Summary

- Projects on the overview page now display in alphabetical order by name
- Uses `toSorted()` with `localeCompare()` for proper alphabetical sorting
- Added test coverage to verify sorting behavior

## Changes

- `ProjectCardView.tsx`: Sort projects before mapping to cards
- `ProjectCardView.test.tsx`: Added test case for alphabetical sorting

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Projects on the overview page now appear in alphabetical order by name.
  * This ensures a consistent, easier-to-scan project list regardless of the order they were added.

* **Tests**
  * Added coverage to verify projects are displayed in the expected alphabetical order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->