### PR TITLE
fix(aurora): projectOverviewBanner to only show when no service is active

### DIFF
--- a/.changeset/gate-project-overview-banner.md
+++ b/.changeset/gate-project-overview-banner.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+fix(aurora): gate projectOverviewBanner to only show when no service is active

--- a/packages/aurora/src/client/components/ContentHeader/ContentHeader.tsx
+++ b/packages/aurora/src/client/components/ContentHeader/ContentHeader.tsx
@@ -36,9 +36,10 @@ export function ContentHeader({ title, projectId, description, actions, badges }
       <Slot component={slots.serviceBanner} useShadowDOM={false} currentService={currentService} />
     ) : null
 
-  const projectOverviewBanner = slots?.projectOverviewBanner ? (
-    <Slot component={slots.projectOverviewBanner} useShadowDOM={false} />
-  ) : null
+  const projectOverviewBanner =
+    slots?.projectOverviewBanner && !currentService ? (
+      <Slot component={slots.projectOverviewBanner} useShadowDOM={false} />
+    ) : null
 
   return (
     <header className="mb-8">


### PR DESCRIPTION
The projectOverviewBanner should only appear on the project overview page, not on service pages. This change gates it by checking if currentService is undefined, similar to how serviceBanner is only shown when currentService is present.


# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The project overview banner now appears only when no service is active, preventing it from showing in the wrong context.

* **Chores**
  * Updated the release metadata for the next patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->