### PR TITLE
feat(aurora): add debug option to AuroraServerConfig

### DIFF
--- a/.changeset/add-debug-to-server-config.md
+++ b/.changeset/add-debug-to-server-config.md
@@ -1,0 +1,9 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+feat(aurora): add debug option to AuroraServerConfig
+
+Add missing `debug` configuration option to AuroraServerConfig and pass it
+through to contextConfig, allowing consumers to explicitly control OpenStack
+session debug logging behavior via server configuration.

--- a/packages/aurora/src/server/server.ts
+++ b/packages/aurora/src/server/server.ts
@@ -30,6 +30,7 @@ export async function createServer(config: AuroraServerConfig): Promise<FastifyI
     cookieName: config.cookieName,
     cookieDomain: config.cookieDomain,
     insecureCookies: config.insecureCookies,
+    debug: config.debug,
   }
 
   const appRouter = buildAppRouter(config.policyDir, config.routers ?? [])

--- a/packages/aurora/src/types/index.ts
+++ b/packages/aurora/src/types/index.ts
@@ -27,6 +27,12 @@ export interface AuroraServerConfig {
    */
   insecureCookies?: boolean
   /**
+   * Enable debug logging for OpenStack session operations.
+   * Logs HTTP requests/responses to help diagnose API issues.
+   * Default: false in production, true in development
+   */
+  debug?: boolean
+  /**
    * Absolute path to a directory containing consumer-supplied OpenStack policy
    * files (e.g. compute.yaml, image.yaml).  Files found here take precedence
    * over the legacy in-tree permission_custom_policies/ directory.


### PR DESCRIPTION
## Summary
- Add `debug` configuration option to `AuroraServerConfig`
- Pass `debug` through to `contextConfig` in server initialization

## Motivation
The `debug` option was already defined in `ContextConfig` and used in `createContext` to control OpenStack session debug logging, but it was missing from `AuroraServerConfig` and not being passed through from the server configuration. This meant consumers couldn't explicitly configure debug logging behavior.

## Changes
- Added `debug?: boolean` field to `AuroraServerConfig` interface with JSDoc documentation
- Updated `contextConfig` object creation in `createServer` to include `config.debug`

## Test plan
- TypeScript compilation passes
- Configuration now flows from `AuroraServerConfig` → `contextConfig` → `createContext`
- Default behavior unchanged (falls back to `NODE_ENV !== "production"` when not set)