### PR TITLE
feat(aurora): add user details labels

### DIFF
--- a/.changeset/purple-chairs-hide.md
+++ b/.changeset/purple-chairs-hide.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Add user ID and domain labels

--- a/packages/aurora/src/client/components/navigation/UserMenu.tsx
+++ b/packages/aurora/src/client/components/navigation/UserMenu.tsx
@@ -45,8 +45,8 @@ export function UserMenu() {
           <>
             <PopupMenuSection>
               <PopupMenuSectionHeading>
-                <div className="font-semibold">{user?.name}</div>
-                {user?.domain?.name && <div className="text-xs opacity-60">{user.domain.name}</div>}
+                <div className="font-semibold">User ID: {user?.name}</div>
+                {user?.domain?.name && <div className="text-xs opacity-60">User Domain: {user.domain.name}</div>}
               </PopupMenuSectionHeading>
             </PopupMenuSection>
             <PopupMenuSectionSeparator />


### PR DESCRIPTION
# Summary

Add User ID and User Domain labels to improve UX

<img width="213" height="203" alt="Screenshot 2026-07-06 at 08 33 54" src="https://github.com/user-attachments/assets/644f9663-148a-4a20-8342-1402119d6e65" />

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- Go Live List

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the user menu to display clearer labels for account details, showing “User ID” and “User Domain” alongside the values.
  
* **Chores**
  * Included a patch release note for the Aurora package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->