### PR TITLE
fix(aurora): pass router as prop to AuthProvider to avoid useRouter warning

### DIFF
--- a/packages/aurora/src/client/App.tsx
+++ b/packages/aurora/src/client/App.tsx
@@ -90,7 +90,7 @@ const App = (props: AppProps) => {
         <AppShellProvider shadowRoot={false} theme={currentTheme}>
           <trpcReact.Provider client={reactClient} queryClient={queryClient}>
             <QueryClientProvider client={queryClient}>
-              <AuthProvider>
+              <AuthProvider router={router}>
                 <NotificationManager position="top-right" />
                 <AppInner
                   router={router}

--- a/packages/aurora/src/client/components/navigation/MainNavigation.test.tsx
+++ b/packages/aurora/src/client/components/navigation/MainNavigation.test.tsx
@@ -22,8 +22,14 @@ beforeAll(() => {
   }
 })
 
+// Mock router for AuthProvider
+const mockRouter = {
+  navigate: vi.fn(),
+  invalidate: vi.fn(),
+}
+
 const TestingProvider = ({ children }: { children: ReactNode }) => (
-  <AuthProvider>
+  <AuthProvider router={mockRouter}>
     <I18nProvider i18n={i18n}>{children}</I18nProvider>
   </AuthProvider>
 )

--- a/packages/aurora/src/client/routes/index.tsx
+++ b/packages/aurora/src/client/routes/index.tsx
@@ -233,6 +233,7 @@ export function AuthLoginPage() {
               id="user"
               type="text"
               placeholder={t`Enter your username`}
+              autoComplete="username"
               className={textinputstyles}
               onChange={(e) => {
                 setForm({ ...form, user: e.target.value })
@@ -249,6 +250,7 @@ export function AuthLoginPage() {
             <input
               id="password"
               type="password"
+              autoComplete="current-password"
               required
               className={textinputstyles}
               onChange={(e) => {

--- a/packages/aurora/src/client/store/AuthProvider.test.tsx
+++ b/packages/aurora/src/client/store/AuthProvider.test.tsx
@@ -3,20 +3,26 @@ import { renderHook, act } from "@testing-library/react"
 import { AuthProvider, useAuth } from "./AuthProvider"
 import type { User } from "./AuthProvider"
 import { ReactNode } from "react"
-import { useRouter } from "@tanstack/react-router"
-
-// Mock router — AuthProvider uses useRouter() internally
-vi.mock("../router", () => ({}))
 
 // Extract the non-null user type
 type AuthUser = NonNullable<User>
 
-const wrapper = ({ children }: { children: ReactNode }) => <AuthProvider>{children}</AuthProvider>
+// Mock router object passed as prop
+const mockRouter = {
+  navigate: vi.fn(),
+  invalidate: vi.fn(),
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => <AuthProvider router={mockRouter}>{children}</AuthProvider>
 
 describe("AuthProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers()
+
+    // Reset mock router
+    mockRouter.navigate.mockClear()
+    mockRouter.invalidate.mockClear()
 
     // Mock window.location
     Object.defineProperty(window, "location", {
@@ -138,7 +144,7 @@ describe("AuthProvider", () => {
       expect(result.current.isAuthenticated).toBe(false)
       expect(result.current.user).toBeNull()
       expect(result.current.logoutReason).toBe("manual")
-      expect(useRouter().invalidate).toHaveBeenCalled()
+      expect(mockRouter.invalidate).toHaveBeenCalled()
     })
 
     it("should invalidate router on inactive logout (no modal)", async () => {
@@ -162,7 +168,7 @@ describe("AuthProvider", () => {
       expect(result.current.isAuthenticated).toBe(false)
       expect(result.current.logoutReason).toBe("inactive")
       expect(result.current.showInactivityModal).toBe(false)
-      expect(useRouter().invalidate).toHaveBeenCalled()
+      expect(mockRouter.invalidate).toHaveBeenCalled()
     })
 
     it("should show modal on expired logout", async () => {
@@ -450,7 +456,7 @@ describe("AuthProvider", () => {
       })
 
       expect(result.current.showInactivityModal).toBe(false)
-      expect(useRouter().navigate).toHaveBeenCalledWith({
+      expect(mockRouter.navigate).toHaveBeenCalledWith({
         to: "/",
         search: { redirect: "/dashboard" },
       })
@@ -487,7 +493,7 @@ describe("AuthProvider", () => {
         result.current.closeInactivityModal()
       })
 
-      expect(useRouter().navigate).toHaveBeenCalledWith({
+      expect(mockRouter.navigate).toHaveBeenCalledWith({
         to: "/",
         search: undefined,
       })

--- a/packages/aurora/src/client/store/AuthProvider.tsx
+++ b/packages/aurora/src/client/store/AuthProvider.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useCallback, useState } from "react"
 import { TokenData } from "../../server/Authentication/types/models"
-import { useRouter } from "@tanstack/react-router"
 
 export type User = TokenData["user"] | null
 
@@ -16,10 +15,14 @@ export interface AuthContext {
   redirectAfterModal?: string
 }
 
+interface RouterNavigation {
+  navigate: (options: { to: string; search?: Record<string, unknown> }) => void
+  invalidate: () => void
+}
+
 const AuthContext = React.createContext<AuthContext | null>(null)
 
-export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const router = useRouter()
+export function AuthProvider({ children, router }: { children: React.ReactNode; router: RouterNavigation }) {
   const [user, setUser] = React.useState<User | null>(null)
   const [expiresAt, setExpiresAt] = React.useState<Date | undefined>(undefined)
   const [logoutReason, setLogoutReason] = React.useState<"inactive" | "expired" | "manual" | undefined>(undefined)


### PR DESCRIPTION
## Summary

Fixes the React warning: `useRouter must be used inside a <RouterProvider> component!`

## Changes

- **AuthProvider** now accepts `router` as a prop instead of calling `useRouter()` internally
- This resolves the initialization order issue where `AuthProvider` was mounted outside `RouterProvider` but needed router access
- Created a minimal `RouterNavigation` interface with only the required methods (`navigate`, `invalidate`)
- Updated all tests to pass a mock router object
- Added `autocomplete` attributes to login form inputs for better browser UX

## Technical Details

The previous implementation called `useRouter()` at the top of `AuthProvider`, but `AuthProvider` wraps `RouterProvider` in the component tree:

```
<AuthProvider>        ← called useRouter() here (❌ outside RouterProvider)
  <RouterProvider>    ← provides router context
    ...
  </RouterProvider>
</AuthProvider>
```

Since `RouterProvider` doesn't accept children (it renders the route tree internally), we can't simply move `AuthProvider` inside. The fix passes the router instance as a prop from `App`, where the router is created before rendering.

## Testing

- All existing AuthProvider tests pass (20 tests)
- MainNavigation tests updated and passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sign-in form autofill support for username and password fields.
* **Bug Fixes**
  * Authentication flows now use the app’s router more reliably, helping navigation and session handling behave consistently.
  * Updated login and inactivity-related behavior to work smoothly with the latest app setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->