### PR TITLE
fix(aurora): use correct type export

### DIFF
--- a/.changeset/resolve-merge-conflict.md
+++ b/.changeset/resolve-merge-conflict.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+fix: resolve merge conflict in client index exports

--- a/packages/aurora/src/client/index.ts
+++ b/packages/aurora/src/client/index.ts
@@ -6,4 +6,4 @@ export {
   type TrackEventPayload,
   type OnTrackEventCallback,
 } from "./AuroraApp"
-export type { TrpcClient, trpcClient, trpcReactClient, trpcReact } from "./trpcClient"
+export { type TrpcClient, trpcClient, trpcReactClient, trpcReact } from "./trpcClient"


### PR DESCRIPTION
## Summary
Resolves merge conflict in `packages/aurora/src/client/index.ts` that was blocking the main branch.

## Test plan
- [x] Linting passes
- [x] Build succeeds
- [x] No merge conflicts remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed additional TRPC client utilities for easier access from the client entry point.
  * Kept the existing `TrpcClient` type available while expanding the public client API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->