### PR TITLE
fix(aurora): use glob pattern for dts include in vite config

### DIFF
--- a/.changeset/many-donuts-stop.md
+++ b/.changeset/many-donuts-stop.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Fix missing type declarations for exported hooks and auth provider by using glob patterns in vite-plugin-dts configuration.

--- a/packages/aurora/vite.config.mjs
+++ b/packages/aurora/vite.config.mjs
@@ -65,7 +65,8 @@ export default defineConfig(({ mode }) => {
       tsconfigPaths(),
       isLib &&
         dts({
-          include: ["index.ts", "AuroraApp.tsx", "trpcClient.ts"],
+          include: ["**/*.ts", "**/*.tsx"],
+          exclude: ["routes/**", "**/*.test.*", "routeTree.gen.ts"],
           outDir: "../../dist/client",
           tsconfigPath: "../../tsconfig.json",
           entryRoot: ".",


### PR DESCRIPTION
## Summary

Fix missing type declarations for exported hooks and auth provider by using glob patterns instead of explicit file list.

## Problem

The `vite-plugin-dts` was configured with an explicit list of files:
```javascript
include: ['index.ts', 'AuroraApp.tsx', 'trpcClient.ts']
```

This caused `index.d.ts` to reference `./store/AuthProvider` and `./hooks` but those `.d.ts` files were not generated, resulting in:
```
Cannot find module './store/AuthProvider' or its corresponding type declarations.
```

## Solution

Use glob patterns to automatically include all TypeScript files while excluding routes and tests:
```javascript
include: ['**/*.ts', '**/*.tsx'],
exclude: ['routes/**', '**/*.test.*', 'routeTree.gen.ts'],
```

This is more maintainable - new hooks or store files are automatically included without manual updates to the config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved library build settings to generate TypeScript declarations from a broader set of source files while excluding routes, tests, and generated route tree files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->