### PR TITLE
feat(aurora): add useScope hook for combined URL and auth context

### DIFF
--- a/.changeset/honest-planes-start.md
+++ b/.changeset/honest-planes-start.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": minor
+---
+
+Add `useScope` hook that returns `userDomainId` (from auth context) and `projectId` (from URL params) for convenient scope access

--- a/packages/aurora/src/client/hooks/index.ts
+++ b/packages/aurora/src/client/hooks/index.ts
@@ -14,3 +14,4 @@
 
 export { useProjectId } from "./useProjectId"
 export { useDomainId } from "./useDomainId"
+export { useScope } from "./useScope"

--- a/packages/aurora/src/client/hooks/index.ts
+++ b/packages/aurora/src/client/hooks/index.ts
@@ -1,12 +1,14 @@
 /**
- * URL-based context hooks
+ * Scope context hooks
  *
- * These hooks extract scope information (projectId, domainId) directly from URL params.
- * This follows the principle "URL is the source of truth".
+ * These hooks provide access to scope information:
+ * - useProjectId: extracts projectId from URL params
+ * - useDomainId: extracts domainId from auth context (user's domain)
+ * - useScope: combines projectId (URL) and userDomainId (auth context)
  *
  * Benefits:
- * - Centralized URL param extraction (single point of change during route refactoring)
- * - Type-safe access to route params
+ * - Centralized scope extraction (single point of change during refactoring)
+ * - Type-safe access to scope values
  * - Runtime validation with clear error messages
  * - No prop drilling needed
  * - Easy to test and mock

--- a/packages/aurora/src/client/hooks/useScope.test.ts
+++ b/packages/aurora/src/client/hooks/useScope.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook } from "@testing-library/react"
+import type { AuthContext } from "../store/AuthProvider"
+
+// Mock modules before importing useScope
+vi.mock("@tanstack/react-router", () => ({
+  useParams: vi.fn(),
+}))
+
+vi.mock("../store/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}))
+
+import { useScope } from "./useScope"
+import { useParams } from "@tanstack/react-router"
+import { useAuth } from "../store/AuthProvider"
+
+const mockUseParams = vi.mocked(useParams)
+const mockUseAuth = vi.mocked(useAuth)
+
+// Helper to create a mock auth context
+const createMockAuth = (user: AuthContext["user"]): AuthContext => ({
+  isAuthenticated: !!user,
+  login: vi.fn(),
+  logout: vi.fn(),
+  user,
+})
+
+describe("useScope", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("when user is authenticated with domain and projectId is in URL", () => {
+    it("should return both userDomainId and projectId", () => {
+      mockUseAuth.mockReturnValue(
+        createMockAuth({
+          domain: { id: "domain-123", name: "test-domain" },
+        } as AuthContext["user"])
+      )
+      mockUseParams.mockReturnValue({ projectId: "project-456" })
+
+      const { result } = renderHook(() => useScope())
+
+      expect(result.current).toEqual({
+        userDomainId: "domain-123",
+        projectId: "project-456",
+      })
+    })
+  })
+
+  describe("when user is authenticated but projectId is not in URL", () => {
+    it("should return userDomainId and undefined projectId", () => {
+      mockUseAuth.mockReturnValue(
+        createMockAuth({
+          domain: { id: "domain-123", name: "test-domain" },
+        } as AuthContext["user"])
+      )
+      mockUseParams.mockReturnValue({})
+
+      const { result } = renderHook(() => useScope())
+
+      expect(result.current).toEqual({
+        userDomainId: "domain-123",
+        projectId: undefined,
+      })
+    })
+  })
+
+  describe("when user has no domain", () => {
+    it("should return undefined userDomainId", () => {
+      mockUseAuth.mockReturnValue(createMockAuth({} as AuthContext["user"]))
+      mockUseParams.mockReturnValue({ projectId: "project-456" })
+
+      const { result } = renderHook(() => useScope())
+
+      expect(result.current).toEqual({
+        userDomainId: undefined,
+        projectId: "project-456",
+      })
+    })
+  })
+
+  describe("when user is not authenticated", () => {
+    it("should return undefined userDomainId when user is null", () => {
+      mockUseAuth.mockReturnValue(createMockAuth(null))
+      mockUseParams.mockReturnValue({ projectId: "project-456" })
+
+      const { result } = renderHook(() => useScope())
+
+      expect(result.current).toEqual({
+        userDomainId: undefined,
+        projectId: "project-456",
+      })
+    })
+
+    it("should return undefined userDomainId when user is undefined", () => {
+      mockUseAuth.mockReturnValue(createMockAuth(undefined))
+      mockUseParams.mockReturnValue({})
+
+      const { result } = renderHook(() => useScope())
+
+      expect(result.current).toEqual({
+        userDomainId: undefined,
+        projectId: undefined,
+      })
+    })
+  })
+
+  describe("when both values are undefined", () => {
+    it("should return both values as undefined", () => {
+      mockUseAuth.mockReturnValue(createMockAuth(undefined))
+      mockUseParams.mockReturnValue({})
+
+      const { result } = renderHook(() => useScope())
+
+      expect(result.current).toEqual({
+        userDomainId: undefined,
+        projectId: undefined,
+      })
+    })
+  })
+
+  describe("useParams call", () => {
+    it("should call useParams with strict: false", () => {
+      mockUseAuth.mockReturnValue(
+        createMockAuth({
+          domain: { id: "domain-123", name: "test-domain" },
+        } as AuthContext["user"])
+      )
+      mockUseParams.mockReturnValue({ projectId: "project-456" })
+
+      renderHook(() => useScope())
+
+      expect(mockUseParams).toHaveBeenCalledWith({ strict: false })
+    })
+  })
+})

--- a/packages/aurora/src/client/hooks/useScope.test.ts
+++ b/packages/aurora/src/client/hooks/useScope.test.ts
@@ -107,20 +107,6 @@ describe("useScope", () => {
     })
   })
 
-  describe("when both values are undefined", () => {
-    it("should return both values as undefined", () => {
-      mockUseAuth.mockReturnValue(createMockAuth(undefined))
-      mockUseParams.mockReturnValue({})
-
-      const { result } = renderHook(() => useScope())
-
-      expect(result.current).toEqual({
-        userDomainId: undefined,
-        projectId: undefined,
-      })
-    })
-  })
-
   describe("useParams call", () => {
     it("should call useParams with strict: false", () => {
       mockUseAuth.mockReturnValue(

--- a/packages/aurora/src/client/hooks/useScope.ts
+++ b/packages/aurora/src/client/hooks/useScope.ts
@@ -1,0 +1,13 @@
+import { useParams } from "@tanstack/react-router"
+import { useAuth } from "../store/AuthProvider"
+
+export function useScope() {
+  const auth = useAuth()
+  const { projectId } = useParams({ strict: false })
+
+  const userDomainId = auth.user?.domain?.id
+  return {
+    userDomainId,
+    projectId,
+  }
+}

--- a/packages/aurora/src/client/index.ts
+++ b/packages/aurora/src/client/index.ts
@@ -17,4 +17,4 @@ export {
 } from "./trpcClient"
 
 export { useAuth } from "./store/AuthProvider"
-export { useDomainId, useProjectId } from "./hooks"
+export { useDomainId, useProjectId, useScope } from "./hooks"


### PR DESCRIPTION
## Summary
Adds a new `useScope` hook to the aurora package that provides a convenient way to access both URL-based and authentication-based scope information.

## Changes
- Add `useScope` hook that returns `{ userDomainId, projectId }`
  - `userDomainId`: comes from the authenticated user's domain
  - `projectId`: comes from URL params (using `strict: false` for flexibility with different route structures)
- Export `useScope` from client hooks index and main client index
- Add comprehensive tests covering all scenarios (authenticated/unauthenticated, with/without projectId in URL)

## Usage
```tsx
import { useScope } from '@cobaltcore-dev/aurora/client'

function MyComponent() {
  const { userDomainId, projectId } = useScope()
  
  // Use userDomainId and projectId for API calls
}
```

## Testing
- Added unit tests with full coverage for the hook
- All existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `useScope` hook to expose the current user’s domain and project context.
  * Made `useScope` available through the client package’s public exports.

* **Tests**
  * Added coverage for authenticated, unauthenticated, and incomplete URL or domain context scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->