### PR TITLE
fix(aurora): avoid fetching all projects on project detail page

### DIFF
--- a/.changeset/fix-project-detail-slowdown.md
+++ b/.changeset/fix-project-detail-slowdown.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Fix project detail page slowdown by fetching single project instead of all projects

--- a/packages/aurora/src/client/router.ts
+++ b/packages/aurora/src/client/router.ts
@@ -5,6 +5,7 @@ import type { TrpcReact, TrpcClient } from "./trpcClient"
 export function createAuroraRouter(trpcReact: TrpcReact, trpcClient: TrpcClient) {
   return createRouter({
     routeTree,
+    defaultPendingMs: 0,
     context: {
       trpcReact,
       trpcClient,

--- a/packages/aurora/src/client/router.ts
+++ b/packages/aurora/src/client/router.ts
@@ -5,7 +5,6 @@ import type { TrpcReact, TrpcClient } from "./trpcClient"
 export function createAuroraRouter(trpcReact: TrpcReact, trpcClient: TrpcClient) {
   return createRouter({
     routeTree,
-    defaultPendingMs: 0,
     context: {
       trpcReact,
       trpcClient,

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId.tsx
@@ -31,15 +31,15 @@ export const Route = createFileRoute("/_auth/projects/$projectId")({
       }
     }
 
-    const [availableServices, projects] = await Promise.all([
+    const [availableServices, project] = await Promise.all([
       context.trpcClient?.auth.getAvailableServices.query(),
-      context.trpcClient?.project.getAuthProjects.query().catch(() => null),
+      context.trpcClient?.project.getProject.query({ projectId: params.projectId }).catch(() => null),
     ])
 
     const projectScopeStatus = resolveProjectScope({
       projectId: params.projectId,
       scopeProject: scopeData?.project,
-      userProjects: projects,
+      userProject: project,
     })
 
     if (projectScopeStatus === "scope_failed") {
@@ -53,7 +53,7 @@ export const Route = createFileRoute("/_auth/projects/$projectId")({
     }
 
     const accountId = scopeData?.domain?.id || ""
-    const description = projects?.find((p) => p.id === params.projectId)?.description ?? null
+    const description = project?.description ?? null
 
     return {
       trpcClient: context.trpcClient,

--- a/packages/aurora/src/client/routes/_auth/projects/-components/resolveProjectScope.test.ts
+++ b/packages/aurora/src/client/routes/_auth/projects/-components/resolveProjectScope.test.ts
@@ -7,27 +7,27 @@ describe("resolveProjectScope", () => {
       const result = resolveProjectScope({
         projectId: "project-123",
         scopeProject: { id: "project-123" },
-        userProjects: [{ id: "project-123" }, { id: "project-456" }],
+        userProject: { id: "project-123" },
       })
 
       expect(result).toBe("valid")
     })
 
-    it("returns 'valid' even when userProjects is null if scope succeeded", () => {
+    it("returns 'valid' even when userProject is null if scope succeeded", () => {
       const result = resolveProjectScope({
         projectId: "project-123",
         scopeProject: { id: "project-123" },
-        userProjects: null,
+        userProject: null,
       })
 
       expect(result).toBe("valid")
     })
 
-    it("returns 'valid' even when userProjects is undefined if scope succeeded", () => {
+    it("returns 'valid' even when userProject is undefined if scope succeeded", () => {
       const result = resolveProjectScope({
         projectId: "project-123",
         scopeProject: { id: "project-123" },
-        userProjects: undefined,
+        userProject: undefined,
       })
 
       expect(result).toBe("valid")
@@ -35,51 +35,31 @@ describe("resolveProjectScope", () => {
   })
 
   describe("not_found status", () => {
-    it("returns 'not_found' when scopeProject is undefined and project not in userProjects", () => {
+    it("returns 'not_found' when scopeProject is undefined and userProject id doesn't match", () => {
       const result = resolveProjectScope({
         projectId: "project-999",
         scopeProject: undefined,
-        userProjects: [{ id: "project-123" }, { id: "project-456" }],
+        userProject: { id: "project-123" },
       })
 
       expect(result).toBe("not_found")
     })
 
-    it("returns 'not_found' when scopeProject is null and project not in userProjects", () => {
+    it("returns 'not_found' when scopeProject is null and userProject id doesn't match", () => {
       const result = resolveProjectScope({
         projectId: "project-999",
         scopeProject: null,
-        userProjects: [{ id: "project-123" }, { id: "project-456" }],
+        userProject: { id: "project-123" },
       })
 
       expect(result).toBe("not_found")
     })
 
-    it("returns 'not_found' when scopeProject is undefined and userProjects is empty", () => {
-      const result = resolveProjectScope({
-        projectId: "project-999",
-        scopeProject: undefined,
-        userProjects: [],
-      })
-
-      expect(result).toBe("not_found")
-    })
-
-    it("returns 'not_found' when scopeProject is undefined and userProjects is empty", () => {
-      const result = resolveProjectScope({
-        projectId: "project-999",
-        scopeProject: undefined,
-        userProjects: [],
-      })
-
-      expect(result).toBe("not_found")
-    })
-
-    it("returns 'not_found' when scopeProject has no id property and project not in userProjects", () => {
+    it("returns 'not_found' when scopeProject has no id and userProject id doesn't match", () => {
       const result = resolveProjectScope({
         projectId: "project-999",
         scopeProject: {},
-        userProjects: [{ id: "project-123" }],
+        userProject: { id: "project-123" },
       })
 
       expect(result).toBe("not_found")
@@ -87,61 +67,51 @@ describe("resolveProjectScope", () => {
   })
 
   describe("scope_failed status", () => {
-    it("returns 'scope_failed' when project is in userProjects but scopeProject is undefined", () => {
+    it("returns 'scope_failed' when project matches userProject but scopeProject is undefined", () => {
       const result = resolveProjectScope({
         projectId: "project-123",
         scopeProject: undefined,
-        userProjects: [{ id: "project-123" }, { id: "project-456" }],
+        userProject: { id: "project-123" },
       })
 
       expect(result).toBe("scope_failed")
     })
 
-    it("returns 'scope_failed' when project is in userProjects but scopeProject is null", () => {
+    it("returns 'scope_failed' when project matches userProject but scopeProject is null", () => {
       const result = resolveProjectScope({
         projectId: "project-123",
         scopeProject: null,
-        userProjects: [{ id: "project-123" }, { id: "project-456" }],
+        userProject: { id: "project-123" },
       })
 
       expect(result).toBe("scope_failed")
     })
 
-    it("returns 'scope_failed' when project is in userProjects but scopeProject.id doesn't match", () => {
+    it("returns 'scope_failed' when project matches userProject but scopeProject.id doesn't match", () => {
       const result = resolveProjectScope({
         projectId: "project-123",
         scopeProject: { id: "project-456" },
-        userProjects: [{ id: "project-123" }, { id: "project-456" }],
+        userProject: { id: "project-123" },
       })
 
       expect(result).toBe("scope_failed")
     })
 
-    it("returns 'scope_failed' when project is in userProjects but scopeProject has no id", () => {
-      const result = resolveProjectScope({
-        projectId: "project-123",
-        scopeProject: {},
-        userProjects: [{ id: "project-123" }, { id: "project-456" }],
-      })
-
-      expect(result).toBe("scope_failed")
-    })
-
-    it("returns 'scope_failed' when scopeProject is undefined and userProjects is null (can't verify)", () => {
+    it("returns 'scope_failed' when scopeProject is undefined and userProject is null (can't verify)", () => {
       const result = resolveProjectScope({
         projectId: "project-999",
         scopeProject: undefined,
-        userProjects: null,
+        userProject: null,
       })
 
       expect(result).toBe("scope_failed")
     })
 
-    it("returns 'scope_failed' when scopeProject is undefined and userProjects is undefined (can't verify)", () => {
+    it("returns 'scope_failed' when scopeProject is undefined and userProject is undefined (can't verify)", () => {
       const result = resolveProjectScope({
         projectId: "project-999",
         scopeProject: undefined,
-        userProjects: undefined,
+        userProject: undefined,
       })
 
       expect(result).toBe("scope_failed")
@@ -155,7 +125,7 @@ describe("resolveProjectScope", () => {
       const result = resolveProjectScope({
         projectId: "project-123",
         scopeProject: { id: "project-123" },
-        userProjects: [{ id: "project-123" }],
+        userProject: { id: "project-123" },
       })
 
       expect(validStatuses).toContain(result)

--- a/packages/aurora/src/client/routes/_auth/projects/-components/resolveProjectScope.ts
+++ b/packages/aurora/src/client/routes/_auth/projects/-components/resolveProjectScope.ts
@@ -7,27 +7,27 @@ export type ProjectScopeStatus = "valid" | "not_found" | "scope_failed"
  * @param input - The scope resolution input
  * @param input.projectId - The project ID that was requested to be scoped
  * @param input.scopeProject - The project object returned from the scope operation (null/undefined if scope failed)
- * @param input.userProjects - List of projects the user has access to (null/undefined if couldn't be fetched)
+ * @param input.userProject - The project fetched by ID (null/undefined if not found or couldn't be fetched)
  *
  * @returns ProjectScopeStatus
  * - "valid": The scope operation succeeded and the scoped project matches the requested project ID
- * - "not_found": The project doesn't exist or the user doesn't have access to it (only when userProjects was successfully fetched)
- * - "scope_failed": The project exists in the user's list but the scope operation failed, OR we couldn't fetch the user's project list
+ * - "not_found": The project doesn't exist or the user doesn't have access to it (only when userProject was successfully fetched)
+ * - "scope_failed": The project exists but the scope operation failed, OR we couldn't fetch the project record
  *
  * @example
  * // Successful scope
  * resolveProjectScope({
  *   projectId: "project-123",
  *   scopeProject: { id: "project-123" },
- *   userProjects: [{ id: "project-123" }]
+ *   userProject: { id: "project-123" }
  * }) // returns "valid"
  *
  * @example
- * // Project not found (when we successfully fetched the user's project list)
+ * // Project not found (when we successfully fetched the project record)
  * resolveProjectScope({
  *   projectId: "project-999",
  *   scopeProject: undefined,
- *   userProjects: [{ id: "project-123" }]
+ *   userProject: { id: "project-123" }
  * }) // returns "not_found"
  *
  * @example
@@ -35,34 +35,32 @@ export type ProjectScopeStatus = "valid" | "not_found" | "scope_failed"
  * resolveProjectScope({
  *   projectId: "project-123",
  *   scopeProject: undefined,
- *   userProjects: [{ id: "project-123" }]
+ *   userProject: { id: "project-123" }
  * }) // returns "scope_failed"
  *
  * @example
- * // Can't verify project access (userProjects fetch failed)
+ * // Can't verify project access (userProject fetch failed)
  * resolveProjectScope({
  *   projectId: "project-123",
  *   scopeProject: undefined,
- *   userProjects: null
+ *   userProject: null
  * }) // returns "scope_failed"
  */
 export const resolveProjectScope = (input: {
   projectId: string
   scopeProject: { id?: string } | null | undefined
-  userProjects: { id: string }[] | null | undefined
+  userProject: { id: string } | null | undefined
 }): ProjectScopeStatus => {
   if (input.scopeProject?.id === input.projectId) {
     return "valid"
   }
 
-  // If we couldn't fetch userProjects at all, we can't verify the project's existence.
+  // If we couldn't fetch userProject at all, we can't verify the project's existence.
   // Treat this as a scope failure rather than "not_found" to avoid misleading 404 errors
   // when the real issue is a backend/network failure.
-  if (input.userProjects == null) {
+  if (input.userProject == null) {
     return "scope_failed"
   }
 
-  const isInUserProjects = input.userProjects.some((p) => p.id === input.projectId)
-
-  return isInUserProjects ? "scope_failed" : "not_found"
+  return input.userProject.id === input.projectId ? "scope_failed" : "not_found"
 }

--- a/packages/aurora/src/client/routes/_auth/projects/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/index.tsx
@@ -4,7 +4,7 @@ import { ProjectsOverviewNavBar } from "@/client/routes/_auth/projects/-componen
 import { ProjectCardView } from "@/client/routes/_auth/projects/-components/ProjectCardView"
 import { RouteError } from "@/client/components/Error/RouteError"
 import { TRPCClientError } from "@trpc/client"
-import { Container, ContentHeading } from "@cloudoperators/juno-ui-components"
+import { Container, ContentHeading, Spinner, Stack } from "@cloudoperators/juno-ui-components"
 import { Trans } from "@lingui/react/macro"
 import { z } from "zod"
 import { Slot } from "@/client/components/Slot"
@@ -21,6 +21,12 @@ export const Route = createFileRoute("/_auth/projects/")({
     },
   } satisfies RouteInfo,
   component: ProjectsOverview,
+  pendingComponent: () => (
+    <Stack className="fixed inset-0" distribution="center" alignment="center">
+      <div className="absolute inset-0 backdrop-blur-sm" />
+      <Spinner variant="primary" size="large" />
+    </Stack>
+  ),
   errorComponent: ({ error }) => (
     <RouteError error={error} safeErrorMessage={error instanceof TRPCClientError ? error.message : undefined} />
   ),

--- a/packages/aurora/src/server/Project/routers/projectRouter.test.ts
+++ b/packages/aurora/src/server/Project/routers/projectRouter.test.ts
@@ -87,3 +87,54 @@ describe("projectRouter.getAuthProjects", () => {
     expect(result?.every((p) => p.domain_name === undefined)).toBe(true)
   })
 })
+
+describe("projectRouter.getProject", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("returns the project when found", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ project: { id: "p1", name: "shadowvault", enabled: true } }),
+    } as Response)
+
+    const caller = createCaller(makeCtx())
+    const result = await caller.getProject({ projectId: "p1" })
+
+    expect(result?.id).toBe("p1")
+    expect(result?.name).toBe("shadowvault")
+  })
+
+  it("returns null when project is not found (404)", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: "Not Found" } as Response)
+
+    const caller = createCaller(makeCtx())
+    const result = await caller.getProject({ projectId: "nonexistent" })
+
+    expect(result).toBeNull()
+  })
+
+  it("returns null when access is denied (403)", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 403, statusText: "Forbidden" } as Response)
+
+    const caller = createCaller(makeCtx())
+    const result = await caller.getProject({ projectId: "p1" })
+
+    expect(result).toBeNull()
+  })
+
+  it("returns null when fetch fails", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network error"))
+
+    const caller = createCaller(makeCtx())
+    const result = await caller.getProject({ projectId: "p1" })
+
+    expect(result).toBeNull()
+  })
+
+  it("throws UNAUTHORIZED when no openstack session", async () => {
+    const caller = createCaller(makeCtx({ openstack: undefined }))
+    await expect(caller.getProject({ projectId: "p1" })).rejects.toBeInstanceOf(TRPCError)
+  })
+})

--- a/packages/aurora/src/server/Project/routers/projectRouter.ts
+++ b/packages/aurora/src/server/Project/routers/projectRouter.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 import { TRPCError } from "@trpc/server"
 import { protectedProcedure } from "../../trpc"
-import { Project, projectsResponseSchema } from "../types/models"
+import { Project, projectResponseSchema, projectsResponseSchema } from "../types/models"
 
 /**
  * Helper function to call Identity API endpoints directly
@@ -181,5 +181,36 @@ export const projectRouter = {
       projects.sort((a, b) => a.name.localeCompare(b.name))
 
       return projects
+    }),
+
+  getProject: protectedProcedure
+    .input(z.object({ projectId: z.string() }))
+    .query(async ({ ctx, input }): Promise<Project | null> => {
+      if (!ctx.openstack) {
+        throw new TRPCError({
+          code: "UNAUTHORIZED",
+          message: "No authenticated session",
+        })
+      }
+
+      const token = ctx.openstack.getToken()
+      if (!token?.authToken) {
+        throw new TRPCError({
+          code: "UNAUTHORIZED",
+          message: "No auth token available",
+        })
+      }
+
+      const response = await callIdentityAPI(
+        ctx.identityEndpoint,
+        token.authToken,
+        `projects/${input.projectId}`
+      ).catch(() => null)
+
+      if (!response) return null
+
+      const data = await response.json()
+      const parsed = projectResponseSchema.safeParse(data)
+      return parsed.success ? parsed.data.project : null
     }),
 }


### PR DESCRIPTION
# Summary

On the project detail page (`/projects/:id`), the loader was fetching all projects via `getAuthProjects` just to validate scope and retrieve the project description. On production with large project counts, this made every project page slow - switching between projects felt noticeably laggy. This PR replaces that full-list fetch with a single `getProject` call to `GET /v3/projects/:id`.

Additionally, the projects home page had no `pendingComponent`, causing a blank screen during slow `getAuthProjects` responses.

# Changes Made

- Add `getProject` tRPC procedure fetching a single project by ID from Keystone (`GET /v3/projects/:id`)
- Replace `getAuthProjects` with `getProject` in the `$projectId` loader to avoid fetching the full project list on every project detail page
- Update `resolveProjectScope` to accept `userProject` (single record) instead of `userProjects` (full list)
- Add `pendingComponent` to `/projects` route to show spinner during slow `getAuthProjects` loads

# Related Issues

- Issue 1: [link to issue]

# Screenshots (if applicable)

N/A

# Testing Instructions

1. `pnpm i`
2. `pnpm run test`
3. Navigate to `/projects/:id` directly - verify `getAuthProjects` is no longer called in the network tab
4. Navigate to `/projects` on a slow connection - verify spinner appears immediately instead of a blank screen

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.