### PR TITLE
refactor(aurora): remove monospace font from non-technical UI text

### DIFF
--- a/.changeset/fifty-icons-serve.md
+++ b/.changeset/fifty-icons-serve.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Changed List styling to non monospace

--- a/.changeset/fifty-icons-serve.md
+++ b/.changeset/fifty-icons-serve.md
@@ -2,4 +2,4 @@
 "@cobaltcore-dev/aurora": patch
 ---
 
-Changed List styling to non monospace
+Changed List styling to non-monospace

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     {
       "mode": "auto"
     }
-  ]
+  ],
+  "git.alwaysSignOff": true
 }

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/-components/ActivateImagesModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/-components/ActivateImagesModal.tsx
@@ -65,7 +65,7 @@ export const ActivateImagesModal: React.FC<ActivateImagesModalProps> = ({
                 <div className="jn:bg-theme-background-lvl-1 max-h-24 overflow-y-auto rounded p-4">
                   <ul className="space-y-2">
                     {deactivatedImages.map((imageId) => (
-                      <li key={imageId} className="jn:text-theme-default font-mono">
+                      <li key={imageId} className="jn:text-theme-default">
                         {imageId}
                       </li>
                     ))}
@@ -84,7 +84,7 @@ export const ActivateImagesModal: React.FC<ActivateImagesModalProps> = ({
               <div className="jn:bg-theme-warning/10 max-h-24 overflow-y-auto rounded border border-yellow-500/20 p-4">
                 <ul className="space-y-2">
                   {activeImages.map((imageId) => (
-                    <li key={imageId} className="jn:text-theme-default font-mono">
+                    <li key={imageId} className="jn:text-theme-default">
                       {imageId}
                     </li>
                   ))}

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/-components/DeactivateImagesModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/-components/DeactivateImagesModal.tsx
@@ -68,7 +68,7 @@ export const DeactivateImagesModal: React.FC<DeactivateImagesModalProps> = ({
                 <div className="jn:bg-theme-background-lvl-1 max-h-24 overflow-y-auto rounded p-4">
                   <ul className="space-y-2">
                     {activeImages.map((imageId) => (
-                      <li key={imageId} className="jn:text-theme-default font-mono">
+                      <li key={imageId} className="jn:text-theme-default">
                         {imageId}
                       </li>
                     ))}
@@ -87,7 +87,7 @@ export const DeactivateImagesModal: React.FC<DeactivateImagesModalProps> = ({
               <div className="jn:bg-theme-background-lvl-1 max-h-24 overflow-y-auto rounded p-4">
                 <ul className="space-y-2">
                   {deactivatedImages.map((imageId) => (
-                    <li key={imageId} className="jn:text-theme-default font-mono">
+                    <li key={imageId} className="jn:text-theme-default">
                       {imageId}
                     </li>
                   ))}

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/-components/DeleteImagesModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/-components/DeleteImagesModal.tsx
@@ -78,7 +78,7 @@ export const DeleteImagesModal: React.FC<DeleteImagesModalProps> = ({
                 <div className="jn:bg-theme-background-lvl-1 max-h-24 overflow-y-auto rounded p-4">
                   <ul className="space-y-2">
                     {deletableImages.map((imageId) => (
-                      <li key={imageId} className="jn:text-theme-default font-mono">
+                      <li key={imageId} className="jn:text-theme-default">
                         {imageId}
                       </li>
                     ))}
@@ -97,7 +97,7 @@ export const DeleteImagesModal: React.FC<DeleteImagesModalProps> = ({
               <div className="jn:bg-theme-warning/10 max-h-24 overflow-y-auto rounded border border-yellow-500/20 p-4">
                 <ul className="space-y-2">
                   {protectedImages.map((imageId) => (
-                    <li key={imageId} className="jn:text-theme-default font-mono">
+                    <li key={imageId} className="jn:text-theme-default">
                       {imageId}
                     </li>
                   ))}

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/-components/EditImageMetadataModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/-components/EditImageMetadataModal.tsx
@@ -306,7 +306,7 @@ function EditImageMetadataModalInner({
                       errortext={errors[`edit-${index}`]}
                     />
                   ) : (
-                    <span className="jn:text-theme-high block max-w-xs truncate font-mono" title={entry.key}>
+                    <span className="jn:text-theme-high block max-w-xs truncate" title={entry.key}>
                       {entry.key}
                     </span>
                   )}

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/KeyPairs/-components/KeyPairListView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/KeyPairs/-components/KeyPairListView.tsx
@@ -63,7 +63,7 @@ export function KeyPairListView({ keyPairs }: KeyPairListViewProps) {
                 <tr key={keyPair.id || keyPair.name}>
                   <td className="p-3">{keyPair.name}</td>
                   <td className="p-3">{renderKeyType(keyPair.type)}</td>
-                  <td className="p-3 font-mono text-sm">{formatFingerprint(keyPair.fingerprint)}</td>
+                  <td className="p-3 text-sm">{formatFingerprint(keyPair.fingerprint)}</td>
                   <td className="p-3">{formatDate(keyPair.created_at)}</td>
                   <td></td>
                 </tr>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/EditMetadataModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/EditMetadataModal.tsx
@@ -346,7 +346,7 @@ export const EditMetadataModal = ({
               <span className="text-theme-light text-right">
                 <Trans>Content type</Trans>
               </span>
-              <span className=" ">{objectDetails?.contentType ?? "—"}</span>
+              <span>{objectDetails?.contentType ?? "—"}</span>
 
               <span className="text-theme-light text-right">
                 <Trans>ETag</Trans>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/EditMetadataModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/EditMetadataModal.tsx
@@ -346,12 +346,12 @@ export const EditMetadataModal = ({
               <span className="text-theme-light text-right">
                 <Trans>Content type</Trans>
               </span>
-              <span className="font-mono">{objectDetails?.contentType ?? "—"}</span>
+              <span className=" ">{objectDetails?.contentType ?? "—"}</span>
 
               <span className="text-theme-light text-right">
                 <Trans>ETag</Trans>
               </span>
-              <span className="font-mono break-all">{objectDetails?.etag ?? "—"}</span>
+              <span className="break-all">{objectDetails?.etag ?? "—"}</span>
 
               <span className="text-theme-light text-right">
                 <Trans>Size</Trans>
@@ -375,9 +375,7 @@ export const EditMetadataModal = ({
                 <p className="text-theme-light text-xs">
                   <Trans>Stored as x-amz-meta-* headers. Keys are case-insensitive.</Trans>
                 </p>
-                <p
-                  className={`font-mono text-xs ${isSizeExceeded ? "text-theme-danger font-semibold" : "text-theme-light"}`}
-                >
+                <p className={`text-xs ${isSizeExceeded ? "text-theme-danger font-semibold" : "text-theme-light"}`}>
                   {currentMetadataSize} / {MAX_METADATA_BYTES} bytes
                 </p>
               </div>


### PR DESCRIPTION
Remove font-mono from image IDs, keypair fingerprints, and storage metadata where system fonts are more appropriate. Keep monospace only where functionally necessary (JSON viewer). 

Closes #1089 

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated image list and modal metadata styling to use standard proportional fonts instead of monospaced text.
  * Adjusted object property fields, metadata counters, and key-pair fingerprint display to improve readability while preserving truncation, tooltips, and existing color/formatting behavior.
  * Added a patch release note indicating list styling changes to be non-monospace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->