### PR TITLE
fix(portal): swift container limits tooltip not showing on hover

### DIFF
--- a/.changeset/fix-mock-context-type.md
+++ b/.changeset/fix-mock-context-type.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Add explicit return type to createMockContext to fix TypeScript build error

--- a/.changeset/sweet-planets-travel.md
+++ b/.changeset/sweet-planets-travel.md
@@ -1,5 +1,0 @@
----
-"@cobaltcore-dev/aurora": patch
----
-
-fixed tooltip in swift

--- a/.changeset/sweet-planets-travel.md
+++ b/.changeset/sweet-planets-travel.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+fixed tooltip in swift

--- a/.changeset/til-tooltip-fix.md
+++ b/.changeset/til-tooltip-fix.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Fix Swift container limits tooltip not appearing on hover

--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -18,6 +18,8 @@ runs:
         node-version: ${{ inputs.node-version }}
     - name: Setup pnpm
       uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      with:
+        version: 11.18.0
     - name: Verify pnpm supports minimum-release-age (>=10.16)
       run: |
         PNPM_MINOR=$(pnpm --version | cut -d. -f2)

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/ContainerLimitsTooltip.test.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/ContainerLimitsTooltip.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from "vitest"
-import { render, screen, act } from "@testing-library/react"
+import { render, screen, act, fireEvent } from "@testing-library/react"
 import { PortalProvider } from "@cloudoperators/juno-ui-components"
 import { i18n } from "@lingui/core"
 import { I18nProvider } from "@lingui/react"
@@ -97,11 +97,23 @@ describe("ContainerLimitsTooltip", () => {
 
     test("icon has correct data-state when closed", () => {
       renderTooltip()
-      expect(screen.getByRole("img", { name: /info/i })).toHaveAttribute("data-state", "closed")
+      const button = screen.getByRole("img", { name: /info/i }).closest("button")!
+      expect(button).toHaveAttribute("data-state", "closed")
     })
 
     test("tooltip content is visible when open", () => {
       renderOpenTooltip(mockServiceInfo)
+      expect(screen.getByText("Limits")).toBeInTheDocument()
+    })
+
+    test("tooltip appears on hover", async () => {
+      renderTooltip(mockServiceInfo, mockAccountInfo)
+      const trigger = screen.getByRole("img", { name: /info/i }).closest("button")!
+      await act(async () => {
+        fireEvent.mouseEnter(trigger)
+      })
+      expect(screen.getByRole("tooltip")).toBeInTheDocument()
+      expect(screen.getByText("Account")).toBeInTheDocument()
       expect(screen.getByText("Limits")).toBeInTheDocument()
     })
   })

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/ContainerLimitsTooltip.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/ContainerLimitsTooltip.tsx
@@ -63,8 +63,10 @@ export const ContainerLimitsTooltip = ({ serviceInfo, accountInfo, open }: Conta
 
   return (
     <Tooltip triggerEvent="hover" placement="bottom-end" open={open}>
-      <TooltipTrigger asChild>
-        <Icon icon="info" size="20px" className="text-theme-light hover:text-theme-default cursor-pointer" />
+      <TooltipTrigger>
+        <span>
+          <Icon icon="info" size="20px" className="text-theme-light hover:text-theme-default cursor-pointer" />
+        </span>
       </TooltipTrigger>
       <TooltipContent className="z-10 w-72 text-sm">
         <span className="flex flex-col gap-3 p-1">

--- a/packages/aurora/src/server/Storage/routers/ceph/mockContext.ts
+++ b/packages/aurora/src/server/Storage/routers/ceph/mockContext.ts
@@ -22,7 +22,16 @@ interface MockContextOptions {
   region?: string
 }
 
-export const createMockContext = (options: MockContextOptions = {}) => {
+export const createMockContext = (
+  options: MockContextOptions = {}
+): AuroraPortalContext & {
+  mockIdentity: {
+    get: ReturnType<typeof vi.fn>
+    post: ReturnType<typeof vi.fn>
+    del: ReturnType<typeof vi.fn>
+    availableEndpoints: ReturnType<typeof vi.fn>
+  }
+} => {
   const {
     shouldFailAuth = false,
     hasCredentials = true,


### PR DESCRIPTION
Wrapped Icon in span and removed asChild from TooltipTrigger to match Juno's hover tooltip pattern. The Icon component wasn't forwarding refs correctly with asChild.

Closes #1108

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
