### PR TITLE
feat(portal): sync floating IP filters with URL params

### DIFF
--- a/.changeset/floating-ip-url-sync.md
+++ b/.changeset/floating-ip-url-sync.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Sync floating IP filters, sort, and search to URL with fallback for invalid params

--- a/.changeset/floating-ips-validation.md
+++ b/.changeset/floating-ips-validation.md
@@ -1,5 +1,0 @@
----
-"@cobaltcore-dev/aurora": patch
----
-
-Replace catch() with safeParse validation for floating IP URL params

--- a/.changeset/floating-ips-validation.md
+++ b/.changeset/floating-ips-validation.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Replace catch() with safeParse validation for floating IP URL params

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/-components/FloatingIpsList.test.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/-components/FloatingIpsList.test.tsx
@@ -384,7 +384,7 @@ describe("FloatingIps List", () => {
         expect(mockNavigate).toHaveBeenCalledWith(
           expect.objectContaining({
             search: expect.any(Function),
-            replace: true,
+            replace: false,
           })
         )
         // Verify the search updater function sets search correctly

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/-components/FloatingIpsList.test.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/-components/FloatingIpsList.test.tsx
@@ -10,13 +10,24 @@ import { trpcReact } from "@/client/trpcClient"
 import type { AllocateFloatingIpModalProps } from "./-modals/AllocateFloatingIpModal"
 import { FloatingIpsList } from "./FloatingIpsList"
 
-// Mock useParams
+// Mock useParams, useSearch, useNavigate
+let mockSearchParams: Record<string, unknown> = {}
+
+const mockNavigate = vi.fn(
+  (opts: { search: (prev: Record<string, unknown>) => Record<string, unknown>; replace?: boolean }) => {
+    if (typeof opts.search === "function") {
+      mockSearchParams = opts.search(mockSearchParams)
+    }
+  }
+)
+
 vi.mock("@tanstack/react-router", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tanstack/react-router")>()
   return {
     ...actual,
     useParams: vi.fn(() => ({ projectId: "test-project" })),
-    useNavigate: vi.fn(() => vi.fn()),
+    useSearch: vi.fn(() => mockSearchParams),
+    useNavigate: vi.fn(() => mockNavigate),
   }
 })
 
@@ -181,6 +192,8 @@ describe("FloatingIps List", () => {
   })
 
   beforeEach(() => {
+    mockSearchParams = {}
+    mockNavigate.mockClear()
     i18n.activate("en")
     vi.mocked(trpcReact.network.floatingIp.create.useMutation).mockReturnValue(createMockMutationResult())
     vi.mocked(trpcReact.network.canUser.useQuery).mockReturnValue({
@@ -368,8 +381,17 @@ describe("FloatingIps List", () => {
       await user.click(searchButton)
 
       await waitFor(() => {
-        const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1][0]
-        expect(lastCall).toMatchObject({ searchTerm: "203.0.113" })
+        expect(mockNavigate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            search: expect.any(Function),
+            replace: true,
+          })
+        )
+        // Verify the search updater function sets search correctly
+        const lastCall = mockNavigate.mock.calls[mockNavigate.mock.calls.length - 1][0]
+        const searchUpdater = lastCall.search as (prev: Record<string, unknown>) => Record<string, unknown>
+        const result = searchUpdater({})
+        expect(result).toMatchObject({ search: "203.0.113" })
       })
     })
 
@@ -467,14 +489,90 @@ describe("FloatingIps List", () => {
       await user.type(searchbox, "203{Enter}")
 
       await waitFor(() => {
-        const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1][0]
-        expect(lastCall).toMatchObject({
-          sort_key: "floating_ip_address",
-          sort_dir: "asc",
+        // Verify all navigation calls happened with correct params
+        const calls = mockNavigate.mock.calls
+        expect(calls.length).toBeGreaterThan(0)
+
+        // Check final state by calling all updaters in sequence
+        let finalParams = {}
+        calls.forEach((call) => {
+          if (call[0].search && typeof call[0].search === "function") {
+            finalParams = call[0].search(finalParams)
+          }
+        })
+
+        expect(finalParams).toMatchObject({
+          sortBy: "floating_ip_address",
+          sortDirection: "asc",
           status: "ACTIVE",
-          searchTerm: "203",
+          search: "203",
         })
       })
+    })
+  })
+
+  describe("URL parameter initialization", () => {
+    it("loads filter state from URL params", () => {
+      mockSearchParams = {
+        status: "DOWN",
+        search: "192.168",
+        sortBy: "floating_ip_address",
+        sortDirection: "desc",
+      }
+
+      const mockUseQuery = vi.mocked(trpcReact.network.floatingIp.list.useQuery)
+      mockUseQuery.mockReturnValue(createMockQueryResult<FloatingIp[]>({ data: mockFloatingIps }))
+
+      render(<FloatingIpsList />, { wrapper: createWrapper() })
+
+      // Verify the component uses URL params in the query
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sort_key: "floating_ip_address",
+          sort_dir: "desc",
+          status: "DOWN",
+          searchTerm: "192.168",
+        }),
+        expect.any(Object)
+      )
+    })
+
+    it("uses defaults when URL params are empty", () => {
+      mockSearchParams = {}
+
+      const mockUseQuery = vi.mocked(trpcReact.network.floatingIp.list.useQuery)
+      mockUseQuery.mockReturnValue(createMockQueryResult<FloatingIp[]>({ data: mockFloatingIps }))
+
+      render(<FloatingIpsList />, { wrapper: createWrapper() })
+
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        {
+          project_id: "test-project",
+          sort_key: "fixed_ip_address",
+          sort_dir: "asc",
+        },
+        expect.any(Object)
+      )
+    })
+
+    it("handles partial URL params with defaults for missing values", () => {
+      mockSearchParams = {
+        search: "10.0.0",
+      }
+
+      const mockUseQuery = vi.mocked(trpcReact.network.floatingIp.list.useQuery)
+      mockUseQuery.mockReturnValue(createMockQueryResult<FloatingIp[]>({ data: mockFloatingIps }))
+
+      render(<FloatingIpsList />, { wrapper: createWrapper() })
+
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sort_key: "fixed_ip_address",
+          sort_dir: "asc",
+          searchTerm: "10.0.0",
+        }),
+        expect.any(Object)
+      )
     })
   })
 })

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/-components/FloatingIpsList.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/-components/FloatingIpsList.tsx
@@ -107,7 +107,7 @@ export const FloatingIpsList = () => {
         sortBy: settings.sortBy,
         sortDirection: settings.sortDirection,
       })) as unknown as true,
-      replace: true,
+      replace: false,
     })
   }
 
@@ -120,17 +120,17 @@ export const FloatingIpsList = () => {
           sortBy: prev.sortBy,
           sortDirection: prev.sortDirection,
         })) as unknown as true,
-      replace: true,
+      replace: false,
     })
   }
 
-  const handleSearchChange = (term: string) => {
+  const handleSearchChange = (term: string, replace = false) => {
     navigate({
       search: ((prev: FloatingIpsSearchParams) => ({
         ...prev,
         search: term || undefined,
       })) as unknown as true,
-      replace: true,
+      replace,
     })
   }
 
@@ -221,16 +221,16 @@ export const FloatingIpsList = () => {
                 const v = e.currentTarget.value
                 setLocalSearchTerm(v)
                 clearTimeout(debounceTimer.current)
-                debounceTimer.current = window.setTimeout(() => handleSearchChange(v), 500)
+                debounceTimer.current = window.setTimeout(() => handleSearchChange(v, true), 500)
               }}
               onSearch={(v) => {
                 clearTimeout(debounceTimer.current)
-                handleSearchChange(typeof v === "string" ? v : "")
+                handleSearchChange(typeof v === "string" ? v : "", false)
               }}
               onClear={() => {
                 clearTimeout(debounceTimer.current)
                 setLocalSearchTerm("")
-                handleSearchChange("")
+                handleSearchChange("", false)
               }}
             />
           </Stack>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/-components/FloatingIpsList.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/-components/FloatingIpsList.tsx
@@ -1,31 +1,75 @@
 import { useState, useRef, useEffect } from "react"
 import { Trans, useLingui } from "@lingui/react/macro"
+import { useNavigate, useSearch } from "@tanstack/react-router"
 import { Button, Stack, DataGridToolbar, SearchInput, Message } from "@cloudoperators/juno-ui-components"
 import { FloatingIpQueryParameters } from "@/server/Network/types/floatingIp"
 import { SortInput } from "@/client/components/ListToolbar/SortInput"
 import { SelectedFilters } from "@/client/components/ListToolbar/SelectedFilters"
 import { FiltersInput } from "@/client/components/ListToolbar/FiltersInput"
+import { FilterSettings, SortSettings } from "@/client/components/ListToolbar/types"
 import { trpcReact } from "@/client/trpcClient"
-import { buildFilterParams } from "@/client/utils/buildFilterParams"
-import { useListWithFiltering } from "@/client/utils/useListWithFiltering"
 import { useModal } from "@/client/utils/useModal"
 import { useProjectId } from "@/client/hooks"
 import { FloatingIpListContainer } from "./-table/FloatingIpListContainer"
 import { AllocateFloatingIpModal } from "./-modals/AllocateFloatingIpModal"
-import { applyFilterSelection } from "../urlHelpers"
+import { parseFiltersFromUrl, buildFilterParams, buildUrlSearchParams, applyFilterSelection } from "../urlHelpers"
 
 const DEFAULT_SORT_KEY = "fixed_ip_address"
 const DEFAULT_SORT_DIR = "asc"
 export type FloatingIpsSortKey = NonNullable<FloatingIpQueryParameters["sort_key"]>
 
+type FloatingIpsSearchParams = {
+  status?: string
+  search?: string
+  sortBy?: string
+  sortDirection?: "asc" | "desc"
+}
+
+type RequiredSortSettings = {
+  options: SortSettings["options"]
+  sortBy: string
+  sortDirection: "asc" | "desc"
+}
+
 export const FloatingIpsList = () => {
   const { t } = useLingui()
+  const navigate = useNavigate()
+  const searchParams = useSearch({ strict: false }) as FloatingIpsSearchParams
   const projectId = useProjectId()
   const [allocateModalOpen, toggleAllocateModal] = useModal(false)
-  const [localSearchTerm, setLocalSearchTerm] = useState("")
+  const [localSearchTerm, setLocalSearchTerm] = useState(searchParams.search || "")
   const debounceTimer = useRef<number | undefined>(undefined)
 
   useEffect(() => () => clearTimeout(debounceTimer.current), [])
+
+  const [sortSettings, setSortSettings] = useState<RequiredSortSettings>({
+    options: [
+      { label: t`Fixed IP Address`, value: "fixed_ip_address" },
+      { label: t`Floating IP Address`, value: "floating_ip_address" },
+      { label: t`Floating Network ID`, value: "floating_network_id" },
+      { label: t`ID`, value: "id" },
+      { label: t`Router ID`, value: "router_id" },
+      { label: t`Status`, value: "status" },
+      { label: t`Tenant ID`, value: "tenant_id" },
+      { label: t`Project ID`, value: "project_id" },
+    ],
+    sortBy: searchParams.sortBy || DEFAULT_SORT_KEY,
+    sortDirection: searchParams.sortDirection || DEFAULT_SORT_DIR,
+  })
+
+  const [filterSettings, setFilterSettings] = useState<FilterSettings>({
+    filters: [
+      {
+        displayName: t`Status`,
+        filterName: "status",
+        values: ["ACTIVE", "DOWN", "ERROR"],
+        supportsMultiValue: false,
+      },
+    ],
+    selectedFilters: parseFiltersFromUrl(searchParams),
+  })
+
+  const searchTerm = searchParams.search || ""
 
   const { data: permissions } = trpcReact.network.canUser.useQuery(
     {
@@ -39,32 +83,56 @@ export const FloatingIpsList = () => {
     }
   )
 
-  const { searchTerm, handleSearchChange, sortSettings, handleSortChange, filterSettings, handleFilterChange } =
-    useListWithFiltering<FloatingIpsSortKey>({
-      defaultSortKey: DEFAULT_SORT_KEY,
-      defaultSortDir: DEFAULT_SORT_DIR,
-      sortOptions: [
-        { label: t`Fixed IP Address`, value: "fixed_ip_address" },
-        { label: t`Floating IP Address`, value: "floating_ip_address" },
-        { label: t`Floating Network ID`, value: "floating_network_id" },
-        { label: t`ID`, value: "id" },
-        { label: t`Router ID`, value: "router_id" },
-        { label: t`Status`, value: "status" },
-        // Tenant_id was kept for backward compatibility in case the deprecated tenant ID was used to sort instead of the project ID.
-        { label: t`Tenant ID`, value: "tenant_id" },
-        { label: t`Project ID`, value: "project_id" },
-      ],
-      filterSettings: {
-        filters: [
-          {
-            displayName: t`Status`,
-            filterName: "status",
-            values: ["ACTIVE", "DOWN", "ERROR"],
-            supportsMultiValue: false,
-          },
-        ],
-      },
+  useEffect(() => {
+    const urlFilters = parseFiltersFromUrl(searchParams)
+    const urlSortBy = searchParams.sortBy || DEFAULT_SORT_KEY
+    const urlSortDirection = searchParams.sortDirection || DEFAULT_SORT_DIR
+    const urlSearchTerm = searchParams.search || ""
+
+    setFilterSettings((prev) => ({ ...prev, selectedFilters: urlFilters }))
+    setSortSettings((prev) => ({ ...prev, sortBy: urlSortBy, sortDirection: urlSortDirection }))
+    setLocalSearchTerm(urlSearchTerm)
+  }, [searchParams.status, searchParams.sortBy, searchParams.sortDirection, searchParams.search])
+
+  const handleSortChange = (newSortSettings: SortSettings) => {
+    const settings: RequiredSortSettings = {
+      options: newSortSettings.options,
+      sortBy: newSortSettings.sortBy?.toString() || DEFAULT_SORT_KEY,
+      sortDirection: newSortSettings.sortDirection || DEFAULT_SORT_DIR,
+    }
+    setSortSettings(settings)
+    navigate({
+      search: ((prev: FloatingIpsSearchParams) => ({
+        ...prev,
+        sortBy: settings.sortBy,
+        sortDirection: settings.sortDirection,
+      })) as unknown as true,
+      replace: true,
     })
+  }
+
+  const handleFilterChange = (newFilterSettings: FilterSettings) => {
+    setFilterSettings(newFilterSettings)
+    navigate({
+      search: ((prev: FloatingIpsSearchParams) =>
+        buildUrlSearchParams(newFilterSettings.selectedFilters || [], newFilterSettings.filters, {
+          search: prev.search,
+          sortBy: prev.sortBy,
+          sortDirection: prev.sortDirection,
+        })) as unknown as true,
+      replace: true,
+    })
+  }
+
+  const handleSearchChange = (term: string) => {
+    navigate({
+      search: ((prev: FloatingIpsSearchParams) => ({
+        ...prev,
+        search: term || undefined,
+      })) as unknown as true,
+      replace: true,
+    })
+  }
 
   const {
     data: floatingIps = [],
@@ -74,9 +142,9 @@ export const FloatingIpsList = () => {
   } = trpcReact.network.floatingIp.list.useQuery(
     {
       project_id: projectId,
-      sort_key: sortSettings.sortBy,
+      sort_key: sortSettings.sortBy as FloatingIpsSortKey,
       sort_dir: sortSettings.sortDirection,
-      ...buildFilterParams(filterSettings),
+      ...buildFilterParams(filterSettings.selectedFilters || [], filterSettings.filters),
       ...(searchTerm ? { searchTerm } : {}),
     },
     {

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/index.tsx
@@ -7,12 +7,14 @@ import type { RouteInfo } from "@/client/routes/routeInfo"
 import { ContentHeading } from "@cloudoperators/juno-ui-components"
 import { FloatingIpQueryParametersSchema, FloatingIpStatusSchema } from "@/server/Network/types/floatingIp"
 
-const floatingIpsSearchSchema = z.object({
-  status: FloatingIpStatusSchema.catch("ACTIVE").optional(),
+const floatingIpsSearchFields = {
+  status: FloatingIpStatusSchema.optional(),
   search: z.string().optional(),
-  sortBy: FloatingIpQueryParametersSchema.shape.sort_key.unwrap().catch("fixed_ip_address").optional(),
-  sortDirection: z.enum(["asc", "desc"]).catch("asc").optional(),
-})
+  sortBy: FloatingIpQueryParametersSchema.shape.sort_key.unwrap().optional(),
+  sortDirection: z.enum(["asc", "desc"]).optional(),
+}
+
+const floatingIpsSearchSchema = z.object(floatingIpsSearchFields).passthrough()
 
 export const Route = createFileRoute("/_auth/projects/$projectId/network/floatingips/")({
   staticData: {
@@ -24,7 +26,19 @@ export const Route = createFileRoute("/_auth/projects/$projectId/network/floatin
     sectionCrumb: { labelKey: "Network" },
     crumb: { labelKey: "Floating IPs" },
   } satisfies RouteInfo,
-  validateSearch: floatingIpsSearchSchema,
+  validateSearch: (search) => {
+    const result = floatingIpsSearchSchema.safeParse(search)
+    if (result.success) return result.data
+    return {
+      ...search,
+      status: floatingIpsSearchFields.status.safeParse(search.status).success ? search.status : undefined,
+      search: floatingIpsSearchFields.search.safeParse(search.search).success ? search.search : undefined,
+      sortBy: floatingIpsSearchFields.sortBy.safeParse(search.sortBy).success ? search.sortBy : undefined,
+      sortDirection: floatingIpsSearchFields.sortDirection.safeParse(search.sortDirection).success
+        ? search.sortDirection
+        : undefined,
+    }
+  },
   head: () => ({ meta: [{ title: t`Floating IPs` }] }),
   component: RouteComponent,
 })

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/index.tsx
@@ -1,9 +1,18 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { z } from "zod"
 import { t } from "@lingui/core/macro"
 import { useLingui } from "@lingui/react/macro"
 import { FloatingIpsList } from "./-components/FloatingIpsList"
 import type { RouteInfo } from "@/client/routes/routeInfo"
 import { ContentHeading } from "@cloudoperators/juno-ui-components"
+import { FloatingIpQueryParametersSchema, FloatingIpStatusSchema } from "@/server/Network/types/floatingIp"
+
+const floatingIpsSearchSchema = z.object({
+  status: FloatingIpStatusSchema.catch("ACTIVE").optional(),
+  search: z.string().optional(),
+  sortBy: FloatingIpQueryParametersSchema.shape.sort_key.unwrap().catch("fixed_ip_address").optional(),
+  sortDirection: z.enum(["asc", "desc"]).catch("asc").optional(),
+})
 
 export const Route = createFileRoute("/_auth/projects/$projectId/network/floatingips/")({
   staticData: {
@@ -15,6 +24,7 @@ export const Route = createFileRoute("/_auth/projects/$projectId/network/floatin
     sectionCrumb: { labelKey: "Network" },
     crumb: { labelKey: "Floating IPs" },
   } satisfies RouteInfo,
+  validateSearch: floatingIpsSearchSchema,
   head: () => ({ meta: [{ title: t`Floating IPs` }] }),
   component: RouteComponent,
 })

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/urlHelpers.ts
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/urlHelpers.ts
@@ -1,5 +1,63 @@
 import { SelectedFilter, Filter } from "@/client/components/ListToolbar/types"
 
+type FloatingIpsSearchParams = {
+  status?: string
+  search?: string
+  sortBy?: string
+  sortDirection?: "asc" | "desc"
+}
+
+/**
+ * Parses URL search params into SelectedFilter array for ListToolbar
+ */
+export const parseFiltersFromUrl = (searchParams: FloatingIpsSearchParams): SelectedFilter[] => {
+  const filters: SelectedFilter[] = []
+
+  // Status filter
+  if (searchParams.status) {
+    filters.push({ name: "status", value: searchParams.status })
+  }
+
+  return filters
+}
+
+/**
+ * Builds filter parameters for API request from SelectedFilter array
+ */
+export const buildFilterParams = (
+  selectedFilters: SelectedFilter[],
+  filterDefinitions: Filter[]
+): Record<string, string> => {
+  const params: Record<string, string> = {}
+
+  if (!selectedFilters?.length) return params
+
+  // Group selected filters by filter name
+  const filterGroups = selectedFilters
+    .filter((sf) => !sf.inactive)
+    .reduce(
+      (acc, sf) => {
+        if (!acc[sf.name]) acc[sf.name] = []
+        acc[sf.name].push(sf.value)
+        return acc
+      },
+      {} as Record<string, string[]>
+    )
+
+  // Build parameters based on whether filter supports multiple values
+  Object.entries(filterGroups).forEach(([filterName, values]) => {
+    const filterDef = filterDefinitions.find((f) => f.filterName === filterName)
+
+    if (filterDef?.supportsMultiValue && values.length > 1) {
+      params[filterName] = `in:${values.join(",")}`
+    } else {
+      params[filterName] = values[0]
+    }
+  })
+
+  return params
+}
+
 /**
  * Merges a newly selected filter into the current list.
  * - Ignores duplicates (same name + value).
@@ -16,4 +74,49 @@ export const applyFilterSelection = (
 
   const supportsMulti = filterDefinitions.find((f) => f.filterName === selected.name)?.supportsMultiValue
   return supportsMulti ? [...current, selected] : [...current.filter((f) => f.name !== selected.name), selected]
+}
+
+/**
+ * Builds URL search params object from filter settings for navigation
+ */
+export const buildUrlSearchParams = (
+  selectedFilters: SelectedFilter[],
+  filterDefinitions: Filter[],
+  baseParams: {
+    search?: string
+    sortBy?: string
+    sortDirection?: "asc" | "desc"
+  }
+): FloatingIpsSearchParams => {
+  const newParams: FloatingIpsSearchParams = {
+    search: baseParams.search,
+    sortBy: baseParams.sortBy,
+    sortDirection: baseParams.sortDirection,
+  }
+
+  if (!selectedFilters?.length) return newParams
+
+  const filterGroups = selectedFilters
+    .filter((sf) => !sf.inactive)
+    .reduce(
+      (acc, sf) => {
+        if (!acc[sf.name]) acc[sf.name] = []
+        acc[sf.name].push(sf.value)
+        return acc
+      },
+      {} as Record<string, string[]>
+    )
+
+  Object.entries(filterGroups).forEach(([filterName, values]) => {
+    const filterDef = filterDefinitions.find((f) => f.filterName === filterName)
+
+    if (filterDef?.supportsMultiValue && values.length > 1) {
+      // Type assertion needed because we're dynamically setting filter fields
+      ;(newParams as Record<string, string>)[filterName] = `in:${values.join(",")}`
+    } else {
+      ;(newParams as Record<string, string>)[filterName] = values[0]
+    }
+  })
+
+  return newParams
 }


### PR DESCRIPTION
Refactored FloatingIpsList to persist filter, sort, and search state in URL query parameters, enabling shareable URLs and browser back/forward navigation. 
- Moved filter parsing/building logic from generic utils to route-specific urlHelpers. 
- Ensured that broken Links fall back to default.

Closes #1106 

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Floating IP search, filtering, and sorting are now synchronized with the URL.
  * Filter, search, and sort settings can be preserved and shared through navigable URLs.
  * Invalid or incomplete URL parameters are safely handled with appropriate defaults.

* **Tests**
  * Added coverage for URL initialization, parameter updates, combined settings, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->