### PR TITLE
fix(core): remove conflicting pnpm dependency causing Docker build failures

### DIFF
--- a/.changeset/fix-pnpm-docker.md
+++ b/.changeset/fix-pnpm-docker.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora-dashboard": patch
+---
+
+Remove conflicting pnpm dependency that caused Docker builds to fail with version mismatch

--- a/.changeset/update-pnpm-11-20.md
+++ b/.changeset/update-pnpm-11-20.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora-dashboard": patch
+---
+
+Update pnpm to 11.20.0

--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -18,8 +18,6 @@ runs:
         node-version: ${{ inputs.node-version }}
     - name: Setup pnpm
       uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
-      with:
-        version: 11.18.0
     - name: Verify pnpm supports minimum-release-age (>=10.16)
       run: |
         PNPM_MINOR=$(pnpm --version | cut -d. -f2)

--- a/package.json
+++ b/package.json
@@ -46,9 +46,6 @@
     "turbo": "^2.10.6"
   },
   "packageManager": "pnpm@11.18.0",
-  "dependencies": {
-    "pnpm": "^11.16.0"
-  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-customizable"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prettier-plugin-tailwindcss": "^0.8.1",
     "turbo": "^2.10.6"
   },
-  "packageManager": "pnpm@11.18.0",
+  "packageManager": "pnpm@11.20.0",
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-customizable"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,10 +28,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      pnpm:
-        specifier: ^11.16.0
-        version: 11.16.0
     devDependencies:
       '@changesets/cli':
         specifier: ^2.31.1
@@ -4782,11 +4778,6 @@ packages:
   plimit-lit@1.6.1:
     resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
     engines: {node: '>=12'}
-
-  pnpm@11.16.0:
-    resolution: {integrity: sha512-t2fpqY/IeuwPQtrvzQ6ElBws20XXPE4eaIYPsr39vgMqtZIQVHnl4Fwjf3QMil/9u7UjhXl93CKWdFobu4g+jQ==}
-    engines: {node: '>=22.13'}
-    hasBin: true
 
   pofile@1.1.4:
     resolution: {integrity: sha512-r6Q21sKsY1AjTVVjOuU02VYKVNQGJNQHjTIvs4dEbeuuYfxgYk/DGD2mqqq4RDaVkwdSq0VEtmQUOPe/wH8X3g==}
@@ -10891,8 +10882,6 @@ snapshots:
   plimit-lit@1.6.1:
     dependencies:
       queue-lit: 1.5.2
-
-  pnpm@11.16.0: {}
 
   pofile@1.1.4: {}
 


### PR DESCRIPTION
The package.json had both packageManager: "pnpm@11.18.0" and a dependencies entry for "pnpm": "^11.16.0". This caused corepack to install pnpm 11.16.0 instead of 11.18.0 in Docker builds, which then failed because workspace packages enforce 11.18.0 via devEngines.packageManager.

Removed the dependencies entry - packageManager field is sufficient for corepack.


# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Docker build failures caused by a conflicting pnpm version dependency.
  * Docker builds now use the project’s declared package manager version consistently.

* **Chores**
  * Documented the fix in the package changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->