### PR TITLE
chore(deps): fix js-yaml CVE-2026-59870 security vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,9 @@ overrides:
   fast-uri@<3.1.5: ^3.1.5
   find-my-way@<=9.6.0: ^9.6.1
   js-yaml@<3.14.2: ^3.14.2
-  js-yaml@<3.15.0: ^3.15.0
-  js-yaml@>=3.0.0 <3.15.0: ^3.15.0
+  js-yaml@<3.15.1: ^3.15.1
+  js-yaml@>=3.0.0 <3.15.1: ^3.15.1
+  js-yaml@>=4.0.0 <4.3.1: ^4.3.1
   lodash@<=4.17.23: ^4.17.24
   lodash@>=4.0.0 <=4.17.22: ^4.17.23
   lodash@>=4.0.0 <=4.17.23: ^4.17.24
@@ -3836,12 +3837,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@30.0.1:
@@ -5979,7 +5980,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -8178,7 +8179,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -8188,7 +8189,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -9332,12 +9333,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -9998,7 +9999,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       pify: 4.0.1
       strip-bom: 3.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - tmp
   - "@cloudoperators/juno-ui-components"
-  - js-yaml@3.14.2 || 3.15.0 || 5.1.1 || 5.2.1 || 5.2.2
+  - js-yaml@3.14.2 || 3.15.0 || 3.15.1 || 4.3.1 || 5.1.1 || 5.2.1 || 5.2.2
   - brace-expansion@5.0.7 || 5.0.8 || 5.0.9
   - shell-quote@1.8.4 || 1.8.5
   - fast-uri@3.1.3 || 3.1.4 || 3.1.5 || 4.0.1 || 4.1.1
@@ -27,8 +27,9 @@ overrides:
   fast-uri@<3.1.5: ^3.1.5
   find-my-way@<=9.6.0: ^9.6.1
   js-yaml@<3.14.2: ^3.14.2
-  js-yaml@<3.15.0: ^3.15.0
-  js-yaml@>=3.0.0 <3.15.0: ^3.15.0
+  js-yaml@<3.15.1: ^3.15.1
+  js-yaml@>=3.0.0 <3.15.1: ^3.15.1
+  js-yaml@>=4.0.0 <4.3.1: ^4.3.1
   lodash@<=4.17.23: ^4.17.24
   lodash@>=4.0.0 <=4.17.22: ^4.17.23
   lodash@>=4.0.0 <=4.17.23: ^4.17.24


### PR DESCRIPTION
## Summary
Fix security vulnerabilities in js-yaml (CVE-2026-59870) by updating pnpm overrides to force patched versions.

## Security Issues Fixed
- **js-yaml #166**: Quadratic CPU consumption in !!omap resolution (3.x and 4.x)
  - CVE-2026-59870: DoS via modestly sized YAML documents
  - 3.x line: upgraded to >=3.15.1
  - 4.x line: upgraded to >=4.3.1
- **postcss #148**: Already patched at >=8.5.18 (path traversal fix)

## Changes
- Update `pnpm-workspace.yaml` overrides to force patched versions
- Add `js-yaml@<3.15.1: ^3.15.1` override
- Add `js-yaml@>=3.0.0 <3.15.1: ^3.15.1` override  
- Add `js-yaml@>=4.0.0 <4.3.1: ^4.3.1` override
- Update `minimumReleaseAgeExclude` to allow patched versions

## Verification
```bash
grep "js-yaml@3.15" pnpm-lock.yaml  # Shows 3.15.1
grep "js-yaml@4.3" pnpm-lock.yaml   # Shows 4.3.1
grep "postcss@8.5" pnpm-lock.yaml   # Shows 8.5.25
```

Resolves Dependabot alerts #166 and #148