### PR TITLE
fix(core): changeset package references to unblock releases

### DIFF
--- a/.changeset/fix-pnpm-docker.md
+++ b/.changeset/fix-pnpm-docker.md
@@ -1,5 +1,5 @@
 ---
-"@cobaltcore-dev/aurora-dashboard": patch
+"@cobaltcore-dev/aurora": patch
 ---
 
 Remove conflicting pnpm dependency that caused Docker builds to fail with version mismatch

--- a/.changeset/update-pnpm-11-20.md
+++ b/.changeset/update-pnpm-11-20.md
@@ -1,5 +1,5 @@
 ---
-"@cobaltcore-dev/aurora-dashboard": patch
+"@cobaltcore-dev/aurora": patch
 ---
 
 Update pnpm to 11.20.0


### PR DESCRIPTION
The changesets were referencing @cobaltcore-dev/aurora-dashboard (root package), but changesets requires workspace packages. Changed to @cobaltcore-dev/aurora which is the actual publishable workspace package.

Fixes CI error: 'Found changeset for package @cobaltcore-dev/aurora-dashboard which is not in the workspace'

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected patch release metadata to target the appropriate package.
  * Documented the update to pnpm 11.20.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->