### PR TITLE
fix(portal): add min-width to filter/sort selects app-wide (#1135)

### DIFF
--- a/.changeset/nice-beans-poke.md
+++ b/.changeset/nice-beans-poke.md
@@ -1,0 +1,6 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Aurora: give the filter and sort selects a consistent min-width so their
+menus no longer resize based on the selected value.

--- a/packages/aurora/src/client/components/ListToolbar/FiltersInput.tsx
+++ b/packages/aurora/src/client/components/ListToolbar/FiltersInput.tsx
@@ -9,6 +9,7 @@ import {
   Select,
   SelectProps,
 } from "@cloudoperators/juno-ui-components"
+import { cn } from "@/client/utils/cn"
 import { Filter, SelectedFilter } from "./types"
 
 export type FiltersInputProps = {
@@ -58,7 +59,7 @@ export const FiltersInput = ({
   )
 
   const getSelectProps = (): SelectProps & { "data-testid"?: string } => ({
-    className: `w-full sm:flex-1 sm:min-w-0 ${selectClassName}`,
+    className: cn("w-full sm:min-w-0 sm:flex-1", selectClassName),
     name: "filter",
     "data-testid": "select-filterValue",
     label: t`Filter by`,
@@ -69,7 +70,7 @@ export const FiltersInput = ({
   })
 
   const getComboBoxProps = (): ComboBoxProps & { "data-testid"?: string } => ({
-    className: `w-full sm:flex-1 sm:min-w-0 ${comboboxClassName}`,
+    className: cn("w-full sm:min-w-0 sm:flex-1", comboboxClassName),
     name: "filterValue",
     "data-testid": "combobox-filterValue",
     value: selectedFilterValue,

--- a/packages/aurora/src/client/components/ListToolbar/FiltersInput.tsx
+++ b/packages/aurora/src/client/components/ListToolbar/FiltersInput.tsx
@@ -14,6 +14,8 @@ import { Filter, SelectedFilter } from "./types"
 export type FiltersInputProps = {
   filters: Filter[]
   onChange: (filter: SelectedFilter) => void
+  selectClassName?: string
+  comboboxClassName?: string
 }
 
 function isEmpty(value: unknown) {
@@ -24,7 +26,12 @@ function isEmpty(value: unknown) {
   return false
 }
 
-export const FiltersInput = ({ filters, onChange }: FiltersInputProps) => {
+export const FiltersInput = ({
+  filters,
+  onChange,
+  selectClassName = "",
+  comboboxClassName = "",
+}: FiltersInputProps) => {
   const { t } = useLingui()
 
   const [selectedFilterName, setSelectedFilterName] = useState<string>("")
@@ -51,7 +58,7 @@ export const FiltersInput = ({ filters, onChange }: FiltersInputProps) => {
   )
 
   const getSelectProps = (): SelectProps & { "data-testid"?: string } => ({
-    className: "w-full sm:flex-1 sm:min-w-0",
+    className: `w-full sm:flex-1 sm:min-w-0 ${selectClassName}`,
     name: "filter",
     "data-testid": "select-filterValue",
     label: t`Filter by`,
@@ -62,7 +69,7 @@ export const FiltersInput = ({ filters, onChange }: FiltersInputProps) => {
   })
 
   const getComboBoxProps = (): ComboBoxProps & { "data-testid"?: string } => ({
-    className: "w-full sm:flex-1 sm:min-w-0",
+    className: `w-full sm:flex-1 sm:min-w-0 ${comboboxClassName}`,
     name: "filterValue",
     "data-testid": "combobox-filterValue",
     value: selectedFilterValue,

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Flavors/List.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Flavors/List.tsx
@@ -147,6 +147,7 @@ function FlavorsContent({
             options={sortSettings.options}
             sortBy={sortSettings.sortBy}
             sortDirection={sortSettings.sortDirection ?? "asc"}
+            selectClassName="min-w-40"
             onSortByChange={(v) =>
               handleSortChange({ ...sortSettings, sortBy: v, sortDirection: sortSettings.sortDirection })
             }

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/List.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/List.tsx
@@ -226,6 +226,7 @@ function ImagesContent({
             options={sortSettings.options}
             sortBy={sortSettings.sortBy}
             sortDirection={sortSettings.sortDirection ?? "desc"}
+            selectClassName="min-w-40"
             onSortByChange={(v) =>
               handleSortChange({ ...sortSettings, sortBy: v, sortDirection: sortSettings.sortDirection })
             }
@@ -245,6 +246,8 @@ function ImagesContent({
           <Stack distribution="between" alignment="center">
             <FiltersInput
               filters={activeFilterSettings.filters}
+              selectClassName="min-w-40"
+              comboboxClassName="min-w-40"
               onChange={(selected) => {
                 const newSelected = applyFilterSelection(
                   activeFilterSettings.selectedFilters || [],

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/List.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/-components/Images/List.tsx
@@ -246,8 +246,8 @@ function ImagesContent({
           <Stack distribution="between" alignment="center">
             <FiltersInput
               filters={activeFilterSettings.filters}
-              selectClassName="min-w-40"
-              comboboxClassName="min-w-40"
+              selectClassName="sm:min-w-40"
+              comboboxClassName="sm:min-w-40"
               onChange={(selected) => {
                 const newSelected = applyFilterSelection(
                   activeFilterSettings.selectedFilters || [],

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/-components/FloatingIpsList.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/-components/FloatingIpsList.tsx
@@ -184,6 +184,7 @@ export const FloatingIpsList = () => {
             options={sortSettings.options}
             sortBy={sortSettings.sortBy}
             sortDirection={sortSettings.sortDirection ?? "asc"}
+            selectClassName="min-w-40"
             onSortByChange={(v) =>
               handleSortChange({ ...sortSettings, sortBy: v, sortDirection: sortSettings.sortDirection })
             }
@@ -203,6 +204,8 @@ export const FloatingIpsList = () => {
           <Stack distribution="between" alignment="center">
             <FiltersInput
               filters={filterSettings.filters}
+              selectClassName="min-w-40"
+              comboboxClassName="min-w-40"
               onChange={(selected) => {
                 const newSelected = applyFilterSelection(
                   filterSettings.selectedFilters || [],

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/-components/FloatingIpsList.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/-components/FloatingIpsList.tsx
@@ -204,8 +204,8 @@ export const FloatingIpsList = () => {
           <Stack distribution="between" alignment="center">
             <FiltersInput
               filters={filterSettings.filters}
-              selectClassName="min-w-40"
-              comboboxClassName="min-w-40"
+              selectClassName="sm:min-w-40"
+              comboboxClassName="sm:min-w-40"
               onChange={(selected) => {
                 const newSelected = applyFilterSelection(
                   filterSettings.selectedFilters || [],

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/securitygroups/$securityGroupId/-components/-details/SecurityGroupRulesTable.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/securitygroups/$securityGroupId/-components/-details/SecurityGroupRulesTable.tsx
@@ -165,8 +165,8 @@ export function SecurityGroupRulesTable({
                 {filterSettings && onFilterChange && (
                   <FiltersInput
                     filters={filterSettings.filters}
-                    selectClassName="min-w-40"
-                    comboboxClassName="min-w-40"
+                    selectClassName="sm:min-w-40"
+                    comboboxClassName="sm:min-w-40"
                     onChange={(selected) => {
                       const alreadySelected = (filterSettings.selectedFilters || []).some(
                         (f) => f.name === selected.name && f.value === selected.value

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/securitygroups/$securityGroupId/-components/-details/SecurityGroupRulesTable.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/securitygroups/$securityGroupId/-components/-details/SecurityGroupRulesTable.tsx
@@ -142,6 +142,7 @@ export function SecurityGroupRulesTable({
                 options={sortSettings.options}
                 sortBy={sortSettings.sortBy}
                 sortDirection={sortSettings.sortDirection ?? "asc"}
+                selectClassName="min-w-40"
                 onSortByChange={(v) =>
                   onSortChange({ ...sortSettings, sortBy: v, sortDirection: sortSettings.sortDirection })
                 }
@@ -164,6 +165,8 @@ export function SecurityGroupRulesTable({
                 {filterSettings && onFilterChange && (
                   <FiltersInput
                     filters={filterSettings.filters}
+                    selectClassName="min-w-40"
+                    comboboxClassName="min-w-40"
                     onChange={(selected) => {
                       const alreadySelected = (filterSettings.selectedFilters || []).some(
                         (f) => f.name === selected.name && f.value === selected.value

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/securitygroups/-components/SecurityGroupsList.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/securitygroups/-components/SecurityGroupsList.tsx
@@ -255,8 +255,8 @@ export const SecurityGroups = ({ project: projectId }: SecurityGroupsProps) => {
           <Stack distribution="between" alignment="center">
             <FiltersInput
               filters={filterSettings.filters}
-              selectClassName="min-w-40"
-              comboboxClassName="min-w-40"
+              selectClassName="sm:min-w-40"
+              comboboxClassName="sm:min-w-40"
               onChange={(selected) => {
                 const newSelected = applyFilterSelection(
                   filterSettings.selectedFilters || [],

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/securitygroups/-components/SecurityGroupsList.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/securitygroups/-components/SecurityGroupsList.tsx
@@ -236,6 +236,7 @@ export const SecurityGroups = ({ project: projectId }: SecurityGroupsProps) => {
             options={sortSettings.options}
             sortBy={sortSettings.sortBy}
             sortDirection={sortSettings.sortDirection ?? "asc"}
+            selectClassName="min-w-40"
             onSortByChange={(v) =>
               handleSortChange({ ...sortSettings, sortBy: v, sortDirection: sortSettings.sortDirection })
             }
@@ -254,6 +255,8 @@ export const SecurityGroups = ({ project: projectId }: SecurityGroupsProps) => {
           <Stack distribution="between" alignment="center">
             <FiltersInput
               filters={filterSettings.filters}
+              selectClassName="min-w-40"
+              comboboxClassName="min-w-40"
               onChange={(selected) => {
                 const newSelected = applyFilterSelection(
                   filterSettings.selectedFilters || [],

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Buckets/CorsRulesTab.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Buckets/CorsRulesTab.tsx
@@ -226,7 +226,7 @@ export function CorsRulesTab({ bucketName }: CorsRulesTabProps) {
             options={sortSettings.options}
             sortBy={sortSettings.sortBy}
             sortDirection={sortSettings.sortDirection ?? "asc"}
-            selectClassName="w-40"
+            selectClassName="min-w-40"
             onSortByChange={(value) =>
               handleSortChange({ ...sortSettings, sortBy: value, sortDirection: sortSettings.sortDirection })
             }

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Buckets/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Buckets/index.tsx
@@ -310,7 +310,7 @@ export const CephBuckets = () => {
               options={sortSettings.options}
               sortBy={sortSettings.sortBy}
               sortDirection={sortSettings.sortDirection ?? "asc"}
-              selectClassName="w-40"
+              selectClassName="min-w-40"
               onSortByChange={(value) =>
                 handleSortChange({ ...sortSettings, sortBy: value, sortDirection: sortSettings.sortDirection })
               }

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/ObjectBrowserView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/ObjectBrowserView.tsx
@@ -646,7 +646,7 @@ export function ObjectBrowserView({ bucketName }: ObjectBrowserViewProps) {
               options={sortSettings.options}
               sortBy={sortSettings.sortBy}
               sortDirection={sortSettings.sortDirection ?? "asc"}
-              selectClassName="w-40"
+              selectClassName="min-w-40"
               onSortByChange={(value) =>
                 handleSortChange({ ...sortSettings, sortBy: value, sortDirection: sortSettings.sortDirection })
               }

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/index.tsx
@@ -299,6 +299,7 @@ export const SwiftContainers = () => {
               options={sortSettings.options}
               sortBy={sortSettings.sortBy}
               sortDirection={sortSettings.sortDirection ?? "asc"}
+              selectClassName="min-w-40"
               onSortByChange={(v) =>
                 handleSortChange({ ...sortSettings, sortBy: v, sortDirection: sortSettings.sortDirection })
               }

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/index.tsx
@@ -415,6 +415,7 @@ export const SwiftObjects = ({ provider, containerName }: { provider: string; co
               options={sortSettings.options}
               sortBy={sortSettings.sortBy}
               sortDirection={sortSettings.sortDirection ?? "asc"}
+              selectClassName="min-w-40"
               onSortByChange={(v) =>
                 handleSortChange({ ...sortSettings, sortBy: v, sortDirection: sortSettings.sortDirection })
               }


### PR DESCRIPTION
## What

Add a `min-width` to the filter and sort selects across the app so their
menus no longer resize based on the selected value / input.

Closes #1135.

## Why

Options in Select / ComboBox menus were shrinking or growing depending on
the current value, causing layout shift. Per the issue's rule of thumb, a
select should reserve enough width to preserve the length of its longest
menu entry rather than resizing on change.

## Changes

- Applied a consistent `min-width` to the filter and sort select inputs
  across the app.

## Notes

- Behaviour only — no change to the options or selection logic.
- Value chosen to accommodate the longest menu entry; if any select has an
  unusually long option, its `min-width` can be tuned individually.

## Testing

- [x] Verified selects keep a stable width when changing the selected option
- [x] Checked filter and sort controls across the affected views

## Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved sorting and filtering controls across compute, networking, and storage views.
  * Added consistent minimum widths to selectors and filter inputs for better readability and alignment.
  * Updated filter controls to support customizable styling across different screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->