### PR TITLE
fix(portal): right-align primary buttons / fix button order (#1183)

### DIFF
--- a/.changeset/open-maps-burn.md
+++ b/.changeset/open-maps-burn.md
@@ -1,0 +1,6 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Swift: reorder the objects toolbar so the primary Create Folder action is the
+last (rightmost) button, matching the right-aligned primary-button convention.

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/index.tsx
@@ -421,11 +421,11 @@ export const SwiftObjects = ({ provider, containerName }: { provider: string; co
               onSortDirectionChange={(dir) => handleSortChange({ ...sortSettings, sortDirection: dir })}
             />
           </Stack>
-          <Button variant="primary" className="whitespace-nowrap" onClick={() => setCreateFolderModalOpen(true)}>
-            <Trans>Create Folder</Trans>
-          </Button>
           <Button className="whitespace-nowrap" onClick={() => setUploadModalOpen(true)}>
             <Trans>Upload Object</Trans>
+          </Button>
+          <Button variant="primary" className="whitespace-nowrap" onClick={() => setCreateFolderModalOpen(true)}>
+            <Trans>Create Folder</Trans>
           </Button>
         </Stack>
 


### PR DESCRIPTION
## What

Reorder the Zone 1 toolbar buttons in the Swift objects view so the primary
action sits last (rightmost).

Closes #1183.

## Why

Per the issue's acceptance criteria, the primary/create action should be the
last button and all primary buttons should be right-aligned consistently
across the layout. In the objects toolbar the primary `Create Folder` came
before the secondary `Upload Object`, putting the primary action in the
middle of the row.

## Changes

- `SwiftObjects` (objects `index.tsx`): swapped the button order to
  `Upload Object` (secondary) → `Create Folder` (primary), so the primary
  action is last.

## Notes

- Right-alignment was already correct (`Stack distribution="end"`), so only
  the order changed.
- `SwiftContainers` was reviewed and needs no change: it has a single primary
  `Create Container` button that is already last and right-aligned, so it
  already satisfies the AC.

## Testing

- [x] Verified in the objects view that `Create Folder` is the rightmost button
- [x] Confirmed both buttons still open their respective modals

## Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reordered the object storage toolbar actions so “Upload Object” appears before “Create Folder.”
  * “Create Folder” remains the primary action and is now positioned as the rightmost toolbar button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->