### PR TITLE
fix(aurora): make ClipboardText keyboard-accessible

### DIFF
--- a/packages/aurora/src/client/components/ClipboardText.tsx
+++ b/packages/aurora/src/client/components/ClipboardText.tsx
@@ -62,12 +62,12 @@ const ClipboardText: React.FC<ClipboardTextProps> = ({
           asChild
           data-testid="clipboard-copy-trigger"
         >
-          <div className="group">
+          <button type="button" className="group border-none bg-transparent p-0 text-inherit">
             <Stack direction="horizontal" gap="1" className="items-center hover:underline">
               <span className="select-none">{displayText}</span>
               <Icon icon={copied ? "check" : "contentCopy"} size="18" />
             </Stack>
-          </div>
+          </button>
         </TooltipTrigger>
         <TooltipContent>{getTooltipContent()}</TooltipContent>
       </Tooltip>


### PR DESCRIPTION
Replaces non-semantic div with button element to fix accessibility issues. The button now appears in the accessibility tree, supports keyboard navigation (Tab + Enter/Space), and announces properly to screen readers.

Closes #1077

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Updated the clipboard control to use a semantic button, improving keyboard navigation and assistive technology support while preserving its existing appearance and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->