### PR TITLE
fix(portal): two errors shown for container update failure (#1162)

### DIFF
--- a/.changeset/spotty-ants-shake.md
+++ b/.changeset/spotty-ants-shake.md
@@ -1,0 +1,7 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Swift: a failed container-metadata update no longer shows both an inline error
+and a toast. The failure is shown inline in the edit modal, which stays open so
+the user can adjust and retry.

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/EditContainerMetadataModal.test.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/EditContainerMetadataModal.test.tsx
@@ -895,7 +895,10 @@ describe("EditContainerMetadataModal", () => {
   // ──────────────────────────────────────────────────────────────────────────
 
   describe("Error handling", () => {
-    test("calls onError with container name and error message on mutation failure", async () => {
+    test("shows the error inline in the modal and does not fire onError (toast) on mutation failure", async () => {
+      // #1162: container-update is recoverable, so the failure is surfaced via
+      // the inline banner in the modal body — NOT via a toast. onError must not
+      // be called, so the parent doesn't also raise a toast (no double error).
       mutationError = "Internal Server Error"
       const onError = vi.fn()
       const user = userEvent.setup()
@@ -904,8 +907,10 @@ describe("EditContainerMetadataModal", () => {
       await user.type(screen.getByLabelText(/Total size quota/i), "1000")
       await user.click(screen.getByRole("button", { name: /Save/i }))
       await waitFor(() => {
-        expect(onError).toHaveBeenCalledWith("my-container", "Internal Server Error")
+        expect(screen.getByText(/Failed to update container/i)).toBeInTheDocument()
       })
+      expect(screen.getByText(/Internal Server Error/i)).toBeInTheDocument()
+      expect(onError).not.toHaveBeenCalled()
     })
 
     test("does not close the modal on mutation failure", async () => {

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/EditContainerMetadataModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/EditContainerMetadataModal.tsx
@@ -52,6 +52,9 @@ interface EditContainerMetadataModalProps {
   container: ContainerSummary | null
   onClose: () => void
   onSuccess?: (containerName: string) => void
+  // Retained for API compatibility with callers, but intentionally NOT wired to
+  // a toast: container-update is recoverable, so failures are shown inline in the
+  // modal (see #1162). Kept optional so existing callers still type-check.
   onError?: (containerName: string, errorMessage: string) => void
 }
 
@@ -60,7 +63,6 @@ export const EditContainerMetadataModal = ({
   container,
   onClose,
   onSuccess,
-  onError,
 }: EditContainerMetadataModalProps) => {
   const { t } = useLingui()
   const projectId = useProjectId()
@@ -200,8 +202,11 @@ export const EditContainerMetadataModal = ({
       onSuccess?.(container!.name)
       handleClose()
     },
-    onError: (error) => {
-      onError?.(container!.name, error.message)
+    onError: () => {
+      // #1162: container-metadata update is recoverable, so we surface the
+      // failure via the inline banner in the modal body (updateMutation.isError)
+      // and deliberately do NOT also fire a toast. The modal stays open so the
+      // user can adjust and retry. Showing both was the double-error bug.
     },
   })
 


### PR DESCRIPTION
## What

Stop showing two errors when a container-metadata update fails. The failure
is now surfaced only via the inline banner inside the edit modal; the toast is
no longer fired.

Closes #1162.

## Why

On update failure the modal showed an inline error banner *and* the parent
raised a toast — two errors for one failure. Per the acceptance criteria:
don't do both; if the user can recover, keep the error in the modal (and leave
the modal open). Container-metadata update is recoverable — the user can
adjust quotas/metadata and retry — so the inline banner is the right channel
and the toast is redundant.

## Changes

- `EditContainerMetadataModal`: the update mutation's `onError` no longer calls
  the `onError` prop, so no toast is fired. The inline banner
  (`updateMutation.isError` → "Failed to update container: …") remains, and the
  modal stays open for retry (`handleClose` only runs on success).
- `onError` is kept in the props interface for caller compatibility but removed
  from destructuring (it's intentionally unused now); documented with a comment.

## Notes

- Behaviour for the recoverable case only: modal stays open, single inline
  error, no toast.
- Input validation (quota/metadata) is unchanged — it uses local error state,
  not the toast path, and was never part of the double-error.
- Follow-up (out of scope): `onPropertiesError` in `SwiftContainers` and its
  pass-through in `ContainerTableView` are now unused for this modal and could
  be cleaned up separately.

## Testing

- [x] Updated unit test: on update failure, the inline banner is shown and
      `onError` (toast) is **not** called
- [x] Existing test retained: modal does not close on update failure
- [x] Manual: trigger an update failure — only the in-modal error shows, modal
      stays open, and editing + retry works

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
