### PR TITLE
fix(aurora): optimize DataGrid Action column width

### DIFF
--- a/.changeset/optimize-datagrid-action-columns.md
+++ b/.changeset/optimize-datagrid-action-columns.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/aurora": patch
+---
+
+fix(aurora): optimize DataGrid Action column width and clean up modal title styling

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/-components/-table/FloatingIpListContainer.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/floatingips/-components/-table/FloatingIpListContainer.tsx
@@ -60,9 +60,8 @@ export const FloatingIpListContainer = ({ floatingIps, isLoading, isError, error
       </DataGrid>
     )
   }
-
   return (
-    <DataGrid columns={columnCount}>
+    <DataGrid columns={columnCount} minContentColumns={[columnCount - 1]}>
       <DataGridRow>
         {columns.map((label) => (
           <DataGridHeadCell key={label}>{label}</DataGridHeadCell>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/network/securitygroups/-components/SecurityGroupListContainer.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/network/securitygroups/-components/SecurityGroupListContainer.tsx
@@ -140,7 +140,7 @@ export const SecurityGroupListContainer = ({
 
   return (
     <>
-      <DataGrid columns={hasAnyBulkAction ? 6 : 5}>
+      <DataGrid columns={hasAnyBulkAction ? 6 : 5} minContentColumns={hasAnyBulkAction ? [5] : [4]}>
         <DataGridRow>
           {hasAnyBulkAction && <DataGridHeadCell />}
           {[t`Name`, t`Description`, t`Shared`, t`Stateful`, ""].map((label) => (

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Buckets/BucketTableView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Buckets/BucketTableView.tsx
@@ -126,6 +126,7 @@ export const BucketTableView = ({
           <div style={{ paddingRight: `${scrollbarWidth}px` }}>
             <DataGrid
               columns={columnCount}
+              minContentColumns={[columnCount - 1]}
               gridColumnTemplate={gridColumnTemplate}
               className="buckets"
               data-testid="buckets-table-header"

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/CopyObjectModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/CopyObjectModal.tsx
@@ -263,7 +263,7 @@ export const CopyObjectModal = ({
   return (
     <Modal
       title={
-        <span className="flex max-w-[500px] items-center gap-1">
+        <span className="flex max-w-125 items-center gap-1">
           <span className="shrink-0">
             <Trans>Copy object:</Trans>
           </span>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/EditMetadataModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/EditMetadataModal.tsx
@@ -299,7 +299,7 @@ export const EditMetadataModal = ({
   return (
     <Modal
       title={
-        <span className="flex max-w-[400px] items-center gap-1">
+        <span className="flex max-w-100 items-center gap-1">
           <Trans>
             <span className="shrink-0">Edit metadata:</span>{" "}
             <span className="truncate" title={displayName}>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/GeneratePresignedUrlModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/GeneratePresignedUrlModal.tsx
@@ -252,7 +252,7 @@ export const GeneratePresignedUrlModal = ({
   return (
     <Modal
       title={
-        <span className="flex max-w-[400px] items-center gap-1">
+        <span className="flex max-w-100 items-center gap-1">
           <span className="shrink-0">
             <Trans>Share URL:</Trans>
           </span>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/ObjectVersionHistoryModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/ObjectVersionHistoryModal.tsx
@@ -144,7 +144,7 @@ export const ObjectVersionHistoryModal = ({
 
         {!isLoading && !error && versions.length > 0 && (
           <>
-            <DataGrid columns={6}>
+            <DataGrid columns={6} minContentColumns={[5]}>
               <DataGridRow>
                 <DataGridHeadCell>
                   <Trans>Status</Trans>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/ObjectVersionHistoryModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/ObjectVersionHistoryModal.tsx
@@ -98,7 +98,7 @@ export const ObjectVersionHistoryModal = ({
   return (
     <Modal
       title={
-        <span className="flex max-w-[400px] items-center gap-1 md:max-w-[500px] lg:max-w-[1000px] xl:max-w-[1100px]">
+        <span className="flex max-w-100 items-center gap-1 md:max-w-125 lg:max-w-250 xl:max-w-275">
           <span className="shrink-0">
             <Trans>Version History:</Trans>
           </span>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/ObjectsTableView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/ObjectsTableView.tsx
@@ -388,7 +388,12 @@ export function ObjectsTableView({
       <div className="relative">
         {/* Table Header with scrollbar padding */}
         <div style={{ paddingRight: `${scrollbarWidth}px` }}>
-          <DataGrid columns={columnCount} gridColumnTemplate={gridColumnTemplate} data-testid="objects-table-header">
+          <DataGrid
+            columns={columnCount}
+            gridColumnTemplate={gridColumnTemplate}
+            data-testid="objects-table-header"
+            minContentColumns={[columnCount - 1]}
+          >
             <DataGridRow>
               {showSelection && (
                 <DataGridHeadCell>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/ObjectsTableView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/ObjectsTableView.tsx
@@ -514,7 +514,7 @@ export function ObjectsTableView({
                       <div className="flex items-center gap-2">
                         <button
                           type="button"
-                          className="flex min-w-0 items-center gap-2 rounded text-left hover:underline focus-visible:outline focus-visible:outline-2"
+                          className="flex min-w-0 items-center gap-2 rounded text-left hover:underline focus-visible:outline"
                           onClick={() => onFolderClick(row.prefix)}
                           title={row.prefix}
                         >
@@ -536,7 +536,7 @@ export function ObjectsTableView({
                         )}
                         <button
                           type="button"
-                          className="min-w-0 truncate text-left text-sm hover:underline focus-visible:outline focus-visible:outline-2 disabled:cursor-wait disabled:no-underline"
+                          className="min-w-0 truncate text-left text-sm hover:underline focus-visible:outline disabled:cursor-wait disabled:no-underline"
                           onClick={row.kind === "object" ? () => handlePreviewOrDownload(row) : undefined}
                           disabled={row.kind !== "object" || isStreaming}
                           title={

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/UploadObjectModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Ceph/Objects/UploadObjectModal.tsx
@@ -180,7 +180,7 @@ export const UploadObjectModal = ({
   return (
     <Modal
       title={
-        <span className="flex max-w-[400px] items-center gap-1">
+        <span className="flex max-w-100 items-center gap-1">
           <span className="shrink-0">
             <Trans>Upload object to:</Trans>
           </span>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/ContainerTableView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/ContainerTableView.tsx
@@ -157,6 +157,7 @@ export const ContainerTableView = ({
         <div style={{ paddingRight: `${scrollbarWidth}px` }}>
           <DataGrid
             columns={columnCount}
+            minContentColumns={[columnCount - 1]}
             gridColumnTemplate={gridColumnTemplate}
             className="containers"
             data-testid="containers-table-header"

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/DeleteContainerModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/DeleteContainerModal.tsx
@@ -111,7 +111,7 @@ export const DeleteContainerModal = ({ isOpen, container, onClose, onSuccess, on
   const hasPreflightError = !!(objectsError || metaError)
 
   const modalTitle = (
-    <span className="flex max-w-[400px] items-center gap-2">
+    <span className="flex max-w-100 items-center gap-2">
       <span className="shrink-0">
         <Trans>Delete container:</Trans>
       </span>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/EditContainerMetadataModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/EditContainerMetadataModal.tsx
@@ -428,7 +428,7 @@ export const EditContainerMetadataModal = ({
   return (
     <Modal
       title={
-        <span className="flex max-w-[500px] items-center gap-2">
+        <span className="flex max-w-125 items-center gap-2">
           <span className="shrink-0">
             <Trans>Container:</Trans>
           </span>
@@ -572,7 +572,7 @@ export const EditContainerMetadataModal = ({
                       <TooltipTrigger>
                         <Icon icon="help" size="16" className="text-theme-light cursor-help" />
                       </TooltipTrigger>
-                      <TooltipContent className="z-10 max-w-[220px]">
+                      <TooltipContent className="z-10 max-w-55">
                         <Trans>If there is no index file, the URL displays a list of objects in the container.</Trans>
                       </TooltipContent>
                     </Tooltip>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/ManageContainerAccessModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/ManageContainerAccessModal.tsx
@@ -318,7 +318,7 @@ export const ManageContainerAccessModal = ({
   const modalTitle = (
     <span className="flex items-center gap-2">
       <Trans>Access Control for Container:</Trans>
-      <span className="max-w-[250px] truncate" title={container.name}>
+      <span className="max-w-62.5 truncate" title={container.name}>
         {container.name}
       </span>
     </span>
@@ -580,7 +580,7 @@ function AclFieldLabel({ label }: AclFieldLabelProps) {
         <TooltipTrigger>
           <Icon icon="info" size="14" className="text-theme-light cursor-help" />
         </TooltipTrigger>
-        <TooltipContent className="z-10 max-w-[350px]">
+        <TooltipContent className="z-10 max-w-87.5">
           <Trans>
             Ensure ACL entries are valid — correct project IDs, user IDs, and formats are your responsibility. Invalid
             entries may silently grant or deny unintended access.

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/CopyObjectModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/CopyObjectModal.tsx
@@ -287,7 +287,7 @@ export const CopyObjectModal = ({ isOpen, object, onClose, onSuccess, onError }:
   return (
     <Modal
       title={
-        <span className="flex max-w-[500px] items-center gap-1">
+        <span className="flex max-w-125 items-center gap-1">
           <span className="shrink-0">
             <Trans>Copy Object:</Trans>
           </span>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/CreateFolderModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/CreateFolderModal.tsx
@@ -92,7 +92,7 @@ export const CreateFolderModal = ({ isOpen, currentPrefix, onClose, onSuccess, o
   return (
     <Modal
       title={
-        <span className="flex max-w-[400px] items-center gap-1">
+        <span className="flex max-w-100 items-center gap-1">
           <span className="shrink-0">
             <Trans>Create folder below:</Trans>
           </span>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/DeleteFolderModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/DeleteFolderModal.tsx
@@ -79,7 +79,7 @@ export const DeleteFolderModal = ({ isOpen, folder, onClose, onSuccess, onError 
   return (
     <Modal
       title={
-        <span className="flex max-w-[400px] items-center gap-1">
+        <span className="flex max-w-100 items-center gap-1">
           <span className="shrink-0">
             <Trans>Delete folder:</Trans>
           </span>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/DeleteObjectModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/DeleteObjectModal.tsx
@@ -99,7 +99,7 @@ export const DeleteObjectModal = ({ isOpen, object, onClose, onSuccess, onError 
   return (
     <Modal
       title={
-        <span className="flex max-w-[400px] items-center gap-1">
+        <span className="flex max-w-100 items-center gap-1">
           <span className="shrink-0">
             <Trans>Delete object:</Trans>
           </span>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/EditObjectMetadataModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/EditObjectMetadataModal.tsx
@@ -354,7 +354,7 @@ export const EditObjectMetadataModal = ({
   return (
     <Modal
       title={
-        <span className="flex max-w-[400px] items-center gap-1">
+        <span className="flex max-w-100 items-center gap-1">
           <Trans>
             <span className="shrink-0">Edit metadata:</span>{" "}
             <span className="truncate" title={displayName}>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/GenerateTempUrlModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/GenerateTempUrlModal.tsx
@@ -261,7 +261,7 @@ export const GenerateTempUrlModal = ({
   return (
     <Modal
       title={
-        <span className="flex max-w-[400px] items-center gap-1">
+        <span className="flex max-w-100 items-center gap-1">
           <span className="shrink-0">
             <Trans>Share URL:</Trans>
           </span>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/MoveRenameObjectModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/MoveRenameObjectModal.tsx
@@ -340,7 +340,7 @@ export const MoveRenameObjectModal = ({ isOpen, object, onClose, onSuccess, onEr
   return (
     <Modal
       title={
-        <span className="flex max-w-[500px] items-center gap-1">
+        <span className="flex max-w-125 items-center gap-1">
           <span className="shrink-0">
             <Trans>Move/Rename Object:</Trans>
           </span>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/ObjectsTableView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/ObjectsTableView.tsx
@@ -364,7 +364,7 @@ export const ObjectsTableView = ({
                     {isFolder ? (
                       <button
                         type="button"
-                        className="focus-visible:outline-theme-focus flex min-w-0 items-center gap-2 rounded text-left hover:underline focus-visible:outline focus-visible:outline-2"
+                        className="focus-visible:outline-theme-focus flex min-w-0 items-center gap-2 rounded text-left hover:underline focus-visible:outline-2"
                         onClick={() => onFolderClick(row.name)}
                         data-testid={`folder-${row.name}`}
                         title={row.displayName}
@@ -375,7 +375,7 @@ export const ObjectsTableView = ({
                     ) : (
                       <button
                         type="button"
-                        className="focus-visible:outline-theme-focus flex min-w-0 items-center gap-2 rounded text-left hover:underline focus-visible:outline focus-visible:outline-2 disabled:cursor-wait disabled:opacity-60"
+                        className="focus-visible:outline-theme-focus flex min-w-0 items-center gap-2 rounded text-left hover:underline focus-visible:outline-2 disabled:cursor-wait disabled:opacity-60"
                         onClick={() => handlePreviewOrDownload(row as ObjectRow)}
                         disabled={isStreaming}
                         data-testid={`preview-${row.name}`}
@@ -410,7 +410,7 @@ export const ObjectsTableView = ({
                           onClick={() => handleCancelTransfer(row.name)}
                           aria-label={t`Cancel`}
                           title={t`Cancel`}
-                          className="focus-visible:outline-theme-focus text-theme-light hover:text-theme-danger shrink-0 cursor-pointer rounded focus-visible:outline focus-visible:outline-2"
+                          className="focus-visible:outline-theme-focus text-theme-light hover:text-theme-danger shrink-0 cursor-pointer rounded focus-visible:outline-2"
                           data-testid={`cancel-transfer-${row.name}`}
                         >
                           <Icon icon="cancel" size={18} />

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/ObjectsTableView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/ObjectsTableView.tsx
@@ -256,6 +256,7 @@ export const ObjectsTableView = ({
         <div style={{ paddingRight: `${scrollbarWidth}px` }}>
           <DataGrid
             columns={columnCount}
+            minContentColumns={[columnCount - 1]}
             gridColumnTemplate={gridColumnTemplate}
             className="objects"
             data-testid="objects-table-header"

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/ObjectsTableView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/ObjectsTableView.tsx
@@ -364,7 +364,7 @@ export const ObjectsTableView = ({
                     {isFolder ? (
                       <button
                         type="button"
-                        className="focus-visible:outline-theme-focus flex min-w-0 items-center gap-2 rounded text-left hover:underline focus-visible:outline-2"
+                        className="focus-visible:outline-theme-focus flex min-w-0 items-center gap-2 rounded text-left hover:underline focus-visible:outline focus-visible:outline-2"
                         onClick={() => onFolderClick(row.name)}
                         data-testid={`folder-${row.name}`}
                         title={row.displayName}

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/UploadObjectModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/UploadObjectModal.tsx
@@ -181,7 +181,7 @@ export const UploadObjectModal = ({
   return (
     <Modal
       title={
-        <span className="flex max-w-[400px] items-center gap-1">
+        <span className="flex max-w-100 items-center gap-1">
           <span className="shrink-0">
             <Trans>Upload object to:</Trans>
           </span>


### PR DESCRIPTION
## Summary
Optimize DataGrid Action columns to use minimal width by adding the `minContentColumns` prop to components with overflow button actions.

## Changes

### DataGrid Action Column Optimization
- Added `minContentColumns={[columnCount - 1]}` to 7 DataGrid components:
  - FloatingIpListContainer
  - SecurityGroupListContainer
  - Ceph BucketTableView
  - Ceph ObjectVersionHistoryModal
  - Ceph ObjectsTableView
  - Swift ContainerTableView
  - Swift ObjectsTableView

This ensures the Action column (with overflow buttons) takes up minimal space while remaining as the rightmost column.

### Modal Title Styling Cleanup
Converted arbitrary pixel values to Tailwind spacing scale utilities across storage modals (functionally equivalent, no visual change):
- `max-w-[400px]` → `max-w-100`
- `max-w-[500px]` → `max-w-125`
- `max-w-[250px]` → `max-w-62.5`
- `max-w-[350px]` → `max-w-87.5`
- Responsive variants (`md:`, `lg:`, `xl:`) similarly updated

Affected files:
- Ceph: CopyObjectModal, GeneratePresignedUrlModal, UploadObjectModal, ObjectVersionHistoryModal, EditMetadataModal
- Swift: CopyObjectModal, CreateFolderModal, DeleteFolderModal, DeleteObjectModal, GenerateTempUrlModal, MoveRenameObjectModal, UploadObjectModal, DeleteContainerModal, ManageContainerAccessModal, EditContainerMetadataModal, EditObjectMetadataModal

## Test plan
- [ ] Verify Action columns in affected tables use minimal width
- [ ] Confirm overflow buttons remain functional and properly aligned
- [ ] Check layout in both light and dark modes
- [ ] Verify modal titles display correctly with truncation

Fixes #1168