### PR TITLE
fix(portal): update List on actions in imagesList

### DIFF
--- a/.changeset/green-bears-end.md
+++ b/.changeset/green-bears-end.md
@@ -2,4 +2,4 @@
 "@cobaltcore-dev/aurora": patch
 ---
 
-Fixes padding in images data grid. Implements optimistic updates in images.
+Fixes padding in images data grid. Implements optimistic UI updates for image status changes (activate/deactivate) and triggers proper list refresh after image mutations (create, delete, member changes).

--- a/.changeset/green-bears-end.md
+++ b/.changeset/green-bears-end.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Fixes padding in images data grid. Implements optimistic updates in images.

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ActivateImageModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ActivateImageModal.tsx
@@ -5,7 +5,6 @@ import {
   DescriptionDefinition,
   DescriptionList,
   DescriptionTerm,
-  Message,
   Modal,
   Spinner,
   Stack,
@@ -53,12 +52,8 @@ export const ActivateImageModal: React.FC<ActivateImageModalProps> = ({
         </Stack>
       )}
       {!isLoading && (
-        <div>
-          <Message
-            text={t`Activating this image will allow it to be used to launch new instances again.`}
-            variant="info"
-            className="mb-4"
-          />
+        <>
+          <p className="mb-4">{t`Activating this image will allow it to be used to launch new instances again.`}</p>
 
           <DescriptionList>
             <DescriptionTerm>{t`Name`}</DescriptionTerm>
@@ -84,7 +79,7 @@ export const ActivateImageModal: React.FC<ActivateImageModalProps> = ({
               })()}
             </DescriptionDefinition>
           </DescriptionList>
-        </div>
+        </>
       )}
     </Modal>
   )

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageListView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageListView.tsx
@@ -312,10 +312,15 @@ export function ImageListView({
         },
       })
 
-      // Show success notification and re-fetch image list
+      // Show success notification
       const { message, ...options } = getImageCreatedToast(imageName)
       toast.success(message, options)
-      await utils.compute.listImagesWithPagination.invalidate()
+
+      // Optimistically add the created image to the list
+      onImageUpdated(createdImage)
+
+      // Trigger manual refetch through member status change handler
+      onMemberStatusChanged()
     } catch (error) {
       // Show error notification based on failure point
       if (error instanceof TRPCClientError && error.data?.path === "compute.createImage") {

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageListView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageListView.tsx
@@ -134,62 +134,47 @@ export function ImageListView({
 
   const utils = trpcReact.useUtils()
 
-  const deleteImageMutation = trpcReact.compute.deleteImage.useMutation({
-    onSuccess: () => {
-      utils.compute.listImagesWithPagination.invalidate()
-    },
-  })
+  const deleteImageMutation = trpcReact.compute.deleteImage.useMutation()
 
   const deactivateImageMutation = trpcReact.compute.deactivateImage.useMutation({
-    onSuccess: async () => {
-      await utils.compute.listImagesWithPagination.invalidate()
-      await utils.compute.getImageById.invalidate()
+    onSuccess: () => {
+      utils.compute.getImageById.invalidate()
     },
   })
 
   const reactivateImageMutation = trpcReact.compute.reactivateImage.useMutation({
-    onSuccess: async () => {
-      await utils.compute.listImagesWithPagination.invalidate()
-      await utils.compute.getImageById.invalidate()
+    onSuccess: () => {
+      utils.compute.getImageById.invalidate()
     },
   })
 
   const deleteImagesMutation = trpcReact.compute.deleteImages.useMutation({
     onSuccess: () => {
-      utils.compute.listImagesWithPagination.invalidate()
       setSelectedImages([])
     },
   })
 
   const activateImagesMutation = trpcReact.compute.activateImages.useMutation({
     onSuccess: () => {
-      utils.compute.listImagesWithPagination.invalidate()
       setSelectedImages([])
     },
   })
 
   const deactivateImagesMutation = trpcReact.compute.deactivateImages.useMutation({
     onSuccess: () => {
-      utils.compute.listImagesWithPagination.invalidate()
       setSelectedImages([])
     },
   })
 
   const updateImageMutation = trpcReact.compute.updateImage.useMutation({
     onSuccess: (updatedImage) => {
-      utils.compute.listImagesWithPagination.invalidate()
       utils.compute.getImageById.setData({ project_id: projectId, imageId: updatedImage.id }, updatedImage)
     },
   })
 
   const createImageMutation = trpcReact.compute.createImage.useMutation()
 
-  const updateImageVisibilityMutation = trpcReact.compute.updateImageVisibility.useMutation({
-    onSuccess: (updatedImage) => {
-      utils.compute.listImagesWithPagination.invalidate()
-      onImageUpdated(updatedImage)
-    },
-  })
+  const updateImageVisibilityMutation = trpcReact.compute.updateImageVisibility.useMutation()
 
   const { data } = trpcReact.compute.watchUploadProgress.useSubscription(
     { project_id: projectId, uploadId: uploadId || "" },
@@ -792,13 +777,7 @@ export function ImageListView({
         />
         <CreateImageModal
           isOpen={createModalOpen}
-          onClose={() => {
-            if (uploadId) {
-              utils.compute.listImagesWithPagination.invalidate()
-            }
-
-            setCreateModalOpen(false)
-          }}
+          onClose={() => setCreateModalOpen(false)}
           onCreate={handleCreate}
           isLoading={createImageMutation.isPending || isUploadPending || isCreateInProgress}
           isUploadPending={isUploadPending && !!uploadId}

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageListView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageListView.tsx
@@ -182,11 +182,7 @@ export function ImageListView({
     },
   })
 
-  const createImageMutation = trpcReact.compute.createImage.useMutation({
-    onSuccess: () => {
-      utils.compute.listImagesWithPagination.invalidate()
-    },
-  })
+  const createImageMutation = trpcReact.compute.createImage.useMutation()
 
   const updateImageVisibilityMutation = trpcReact.compute.updateImageVisibility.useMutation({
     onSuccess: (updatedImage) => {
@@ -319,7 +315,7 @@ export function ImageListView({
       // Show success notification and re-fetch image list
       const { message, ...options } = getImageCreatedToast(imageName)
       toast.success(message, options)
-      utils.compute.listImagesWithPagination.invalidate()
+      await utils.compute.listImagesWithPagination.invalidate()
     } catch (error) {
       // Show error notification based on failure point
       if (error instanceof TRPCClientError && error.data?.path === "compute.createImage") {

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageListView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageListView.tsx
@@ -141,16 +141,16 @@ export function ImageListView({
   })
 
   const deactivateImageMutation = trpcReact.compute.deactivateImage.useMutation({
-    onSuccess: () => {
-      utils.compute.listImagesWithPagination.invalidate()
-      utils.compute.getImageById.invalidate()
+    onSuccess: async () => {
+      await utils.compute.listImagesWithPagination.invalidate()
+      await utils.compute.getImageById.invalidate()
     },
   })
 
   const reactivateImageMutation = trpcReact.compute.reactivateImage.useMutation({
-    onSuccess: () => {
-      utils.compute.listImagesWithPagination.invalidate()
-      utils.compute.getImageById.invalidate()
+    onSuccess: async () => {
+      await utils.compute.listImagesWithPagination.invalidate()
+      await utils.compute.getImageById.invalidate()
     },
   })
 
@@ -382,6 +382,11 @@ export function ImageListView({
 
     try {
       await reactivateImageMutation.mutateAsync({ project_id: projectId, imageId })
+
+      // Optimistically update the local state
+      const updatedImage = { ...image, status: IMAGE_STATUSES.ACTIVE }
+      onImageUpdated(updatedImage)
+
       setActivateModalOpen(false)
       setSelectedImage(null)
       const { message, ...options } = getImageActivatedToast(imageName)
@@ -399,6 +404,11 @@ export function ImageListView({
 
     try {
       await deactivateImageMutation.mutateAsync({ project_id: projectId, imageId })
+
+      // Optimistically update the local state
+      const updatedImage = { ...image, status: IMAGE_STATUSES.DEACTIVATED }
+      onImageUpdated(updatedImage)
+
       setDeactivateModalOpen(false)
       setSelectedImage(null)
       const { message, ...options } = getImageDeactivatedToast(imageName)

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageListView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageListView.tsx
@@ -194,11 +194,13 @@ export function ImageListView({
 
   const handleUpdateImageVisibility = async (imageId: string, newVisibility: ImageVisibility, imageName: string) => {
     try {
-      await updateImageVisibilityMutation.mutateAsync({
+      const updatedImage = await updateImageVisibilityMutation.mutateAsync({
         project_id: projectId,
         imageId,
         visibility: newVisibility,
       })
+
+      onImageUpdated(updatedImage)
 
       const { message, ...options } = getImageVisibilityUpdatedToast(imageName, newVisibility)
       toast.success(message, options)

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageListView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageListView.tsx
@@ -513,6 +513,14 @@ export function ImageListView({
       const failedCount = result.failed.length
       const totalCount = imageIds.length
 
+      // Optimistically update successful images
+      result.successful.forEach((imageId) => {
+        const image = images.find((img) => img.id === imageId)
+        if (image) {
+          onImageUpdated({ ...image, status: IMAGE_STATUSES.ACTIVE })
+        }
+      })
+
       if (failedCount === 0) {
         const { message, ...options } = getBulkActivateSuccessToast(successCount, totalCount)
         toast.success(message, options)
@@ -542,6 +550,14 @@ export function ImageListView({
       const successCount = result.successful.length
       const failedCount = result.failed.length
       const totalCount = imageIds.length
+
+      // Optimistically update successful images
+      result.successful.forEach((imageId) => {
+        const image = images.find((img) => img.id === imageId)
+        if (image) {
+          onImageUpdated({ ...image, status: IMAGE_STATUSES.DEACTIVATED })
+        }
+      })
 
       if (failedCount === 0) {
         const { message, ...options } = getBulkDeactivateSuccessToast(successCount, totalCount)

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageListView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageListView.tsx
@@ -190,6 +190,7 @@ export function ImageListView({
 
   const updateImageVisibilityMutation = trpcReact.compute.updateImageVisibility.useMutation({
     onSuccess: (updatedImage) => {
+      utils.compute.listImagesWithPagination.invalidate()
       onImageUpdated(updatedImage)
     },
   })

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageMembersTable.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageMembersTable.tsx
@@ -62,12 +62,14 @@ export const ImageMembersTable: React.FC<ImageMembersTableProps> = ({
   const createMemberMutation = trpcReact.compute.createImageMember.useMutation({
     onSuccess: () => {
       utils.compute.listImageMembers.invalidate({ project_id: projectId, imageId: image.id })
+      utils.compute.listImagesWithPagination.invalidate()
     },
   })
 
   const deleteMemberMutation = trpcReact.compute.deleteImageMember.useMutation({
     onSuccess: () => {
       utils.compute.listImageMembers.invalidate({ project_id: projectId, imageId: image.id })
+      utils.compute.listImagesWithPagination.invalidate()
     },
   })
 

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageMembersTable.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/ImageMembersTable.tsx
@@ -62,14 +62,12 @@ export const ImageMembersTable: React.FC<ImageMembersTableProps> = ({
   const createMemberMutation = trpcReact.compute.createImageMember.useMutation({
     onSuccess: () => {
       utils.compute.listImageMembers.invalidate({ project_id: projectId, imageId: image.id })
-      utils.compute.listImagesWithPagination.invalidate()
     },
   })
 
   const deleteMemberMutation = trpcReact.compute.deleteImageMember.useMutation({
     onSuccess: () => {
       utils.compute.listImageMembers.invalidate({ project_id: projectId, imageId: image.id })
-      utils.compute.listImagesWithPagination.invalidate()
     },
   })
 

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/List.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/-components/List.tsx
@@ -234,13 +234,13 @@ function ImagesContent({
   return (
     <>
       {/* Zone 1 — tabs + sort + create / more actions, no background */}
-      <Stack distribution="between" alignment="center" gap="2">
+      <Stack distribution="between" alignment="center" gap="2" className="pb-2">
         <TabNavigation activeItem={memberStatusView} onActiveItemChange={memberStatusTabs.onActiveItemChange}>
           {memberStatusTabs.items.map((item) => (
             <TabNavigationItem key={item.value} label={item.label} value={item.value} />
           ))}
         </TabNavigation>
-        <Stack gap="0.5" alignment="center">
+        <Stack gap="2" alignment="center">
           <SortInput
             options={sortSettings.options}
             sortBy={sortSettings.sortBy}


### PR DESCRIPTION
# Summary

Closes #1212, Closes #1230, Closes #1116

This PR fixes multiple issues with image list state management where UI updates weren't reflected immediately after mutations. All image operations (create, delete, activate, deactivate, share) now provide instant visual feedback through optimistic updates and proper cache invalidation.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
