### PR TITLE
feat(aurora): replace route-injection with standalone extension sub-app pattern

### DIFF
--- a/.changeset/extension-sub-app-pattern.md
+++ b/.changeset/extension-sub-app-pattern.md
@@ -1,0 +1,23 @@
+---
+"@cobaltcore-dev/aurora": minor
+---
+
+Replace route-injection pattern with standalone extension sub-app pattern for consumer services, and unify the registration vocabulary on "extension".
+
+Breaking changes:
+- `AdditionalProjectService` type renamed to `ServiceExtension`, and the `AuroraAppProps.additionalProjectServices` prop renamed to `serviceExtensions`
+- The `routes` field (type `AnyRoute`) is gone; register a `component` (type `FC<ServiceExtensionProps>`) instead: a standalone React component that mounts its own TanStack Router via `RouterProvider basepath={basePath}`
+- The `component` receives `ServiceExtensionProps` = `{ basePath, context }`, where `context` is a `ServiceExtensionContext`. Seed it into your own router (`createRouter({ routeTree, context })`) and read values via `useRouteContext`
+- `useProjectId` is no longer part of the public API. Extensions receive `projectId` via `ServiceExtensionProps.context` and read it from their own router context instead of the shared hook
+- `servicesRoute` export removed; consumers no longer inject routes into the OSS route tree
+
+New exports:
+- `ServiceExtension` - registration entry for a project-scoped service extension
+- `ServiceExtensionProps` - props type for service extension components (`{ basePath, context }`)
+- `ServiceExtensionContext` - extensible host-context object handed to a mounted extension; seed it into the extension's own router context
+- `PageContentHeader` - re-exported `ContentHeader` component for use in consumer service pages
+
+Additional changes:
+- On `/services/$serviceType/**` routes, OSS shows no section crumb (consistent with compute/network/storage). The project crumb links back to the project home, and extension sub-apps own every crumb below it via `usePushBreadcrumbs`.
+
+OSS now provides a dynamic catch-all route at `/_auth/projects/$projectId/services/$serviceType/**` that mounts the registered service extension component.

--- a/packages/aurora/README.md
+++ b/packages/aurora/README.md
@@ -114,15 +114,16 @@ await server.listen({ host: "0.0.0.0", port: 4000 })
 
 ### `<AuroraApp />`
 
-| Prop              | Type                            | Default          | Description                                                                                                         |
-| ----------------- | ------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `bffEndpoint`     | `string`                        | `"/polaris-bff"` | Must match the server's `bffEndpoint`                                                                               |
-| `theme`           | `"theme-light" \| "theme-dark"` | `"theme-light"`  | Initial theme                                                                                                       |
-| `onThemeChange`   | `(theme) => void`               | —                | Called when the user toggles the theme                                                                              |
-| `appName`         | `string`                        | `"Aurora"`       | App name shown in the header breadcrumb and logo                                                                    |
-| `slots`           | `Slots`                         | —                | Optional UI extension points — see [Slots](#slots)                                                                  |
-| `onTrackEvent`    | `OnTrackEventCallback`          | —                | Called on user interactions for analytics — see [Analytics](#analytics)                                             |
-| `enabledServices` | `string[]`                      | —                | Whitelist of service keys to show. When omitted, all services are shown — see [Enabled services](#enabled-services) |
+| Prop                | Type                            | Default          | Description                                                                                                         |
+| ------------------- | ------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `bffEndpoint`       | `string`                        | `"/polaris-bff"` | Must match the server's `bffEndpoint`                                                                               |
+| `theme`             | `"theme-light" \| "theme-dark"` | `"theme-light"`  | Initial theme                                                                                                       |
+| `onThemeChange`     | `(theme) => void`               | —                | Called when the user toggles the theme                                                                              |
+| `appName`           | `string`                        | `"Aurora"`       | App name shown in the header breadcrumb and logo                                                                    |
+| `slots`             | `Slots`                         | —                | Optional UI extension points — see [Slots](#slots)                                                                  |
+| `onTrackEvent`      | `OnTrackEventCallback`          | —                | Called on user interactions for analytics — see [Analytics](#analytics)                                             |
+| `enabledServices`   | `string[]`                      | —                | Whitelist of service keys to show. When omitted, all services are shown — see [Enabled services](#enabled-services) |
+| `serviceExtensions` | `ServiceExtension[]`            | —                | Consumer-defined services to mount under project scope — see [Service extensions](#service-extensions)              |
 
 ## Slots
 
@@ -213,6 +214,55 @@ enabledServices={import.meta.env.VITE_ENABLED_SERVICES?.split(",").map(s => s.tr
 # .env
 VITE_ENABLED_SERVICES="ceph-containers,securitygroups"
 ```
+
+## Service extensions
+
+Aurora lets you register consumer-owned services (service extensions) that appear alongside the built-in ones in the project navigation. Each extension is tied to an OpenStack catalog entry — Aurora checks whether the service type and name exist in the project's catalog and only shows the service when they do.
+
+Pass an array of service descriptors to `AuroraApp`:
+
+```tsx
+import type { ServiceExtension } from "@cobaltcore-dev/aurora/client"
+import { MyServiceApp } from "./myService/MyServiceApp"
+
+const serviceExtensions: ServiceExtension[] = [
+  {
+    serviceType: "my-service", // OpenStack catalog service type
+    serviceName: "my-service", // OpenStack catalog service name
+    label: "My Service", // Label shown in the side nav and project home
+    component: MyServiceApp, // React component that renders the service UI
+  },
+]
+
+;<AuroraApp serviceExtensions={serviceExtensions} />
+```
+
+The `component` receives a `basePath` (the URL prefix Aurora has mounted the service at) and a `context` object of host-provided data (`ServiceExtensionContext`). Today `context` carries the current `projectId`; it is an extensible object, so future host data (e.g. domain, scope) can be added without changing the component signature.
+
+Because Aurora mounts your extension at `basePath` and strips it from the sub-router, your routes never see `projectId` as a URL param. Seed `context` into your own router context so any component can read it:
+
+```tsx
+import { RouterProvider, createRouter, useRouteContext } from "@tanstack/react-router"
+import { useMemo } from "react"
+import type { ServiceExtensionProps, ServiceExtensionContext } from "@cobaltcore-dev/aurora/client"
+import { routeTree } from "./routeTree.gen"
+
+export function MyServiceApp({ basePath, context }: ServiceExtensionProps) {
+  // Seed the host context into the extension's own router context.
+  const router = useMemo(() => createRouter({ routeTree, context }), [basePath, context])
+  return <RouterProvider basepath={basePath} router={router} />
+}
+
+// In your root route, type the context so it flows through:
+//   createRootRouteWithContext<ServiceExtensionContext>()({ ... })
+//
+// Then read projectId anywhere in your tree:
+function useProjectId(): string {
+  return useRouteContext({ strict: false, select: (c: ServiceExtensionContext) => c.projectId })
+}
+```
+
+Aurora handles routing to your service, breadcrumb rendering for the service level, and showing or hiding the nav entry based on catalog availability. Navigation and breadcrumb details below the service level are the responsibility of the service component.
 
 ## Analytics
 

--- a/packages/aurora/src/client/App.tsx
+++ b/packages/aurora/src/client/App.tsx
@@ -10,7 +10,7 @@ import { I18nProvider } from "@lingui/react"
 import { ErrorBoundary } from "react-error-boundary"
 import { Trans } from "@lingui/react/macro"
 import { NavigationItem } from "./components/navigation/types"
-import type { Slots, OnTrackEventCallback, AdditionalProjectService } from "./AuroraApp"
+import type { Slots, OnTrackEventCallback, ServiceExtension } from "./AuroraApp"
 import { messages as enMessages } from "../locales/en/messages"
 import { setupRouterAnalytics } from "./analytics/setupRouterAnalytics"
 
@@ -27,19 +27,23 @@ type AppProps = {
   appName?: string
   onTrackEvent?: OnTrackEventCallback
   enabledServices?: string[]
-  additionalProjectServices?: AdditionalProjectService[]
+  serviceExtensions?: ServiceExtension[]
 }
 
 // Additional navigation items can be added here and will be passed to the layout via context
 // The items will appear in the main navigation bar and use internal routing (TanStack Router)
 const navItems: NavigationItem[] = []
 
+// Stable reference for the "no extensions" case so a missing prop doesn't allocate a fresh array
+// on every render, which would defeat the buildNavSections useMemo in the project route.
+const EMPTY_SERVICE_EXTENSIONS: ServiceExtension[] = []
+
 const App = (props: AppProps) => {
   useEffect(() => {
     setBffEndpoint(props.bffEndpoint ?? "/polaris-bff")
   }, [props.bffEndpoint])
 
-  const [router] = useState(() => createAuroraRouter(trpcReact, trpcClient, props.additionalProjectServices))
+  const [router] = useState(() => createAuroraRouter(trpcReact, trpcClient, props.serviceExtensions))
 
   const [currentTheme, setCurrentTheme] = useState<"theme-dark" | "theme-light">(props.theme ?? "theme-light")
 
@@ -101,7 +105,7 @@ const App = (props: AppProps) => {
                   appName={props.appName}
                   onTrackEvent={props.onTrackEvent}
                   enabledServices={props.enabledServices}
-                  additionalProjectServices={props.additionalProjectServices ?? []}
+                  serviceExtensions={props.serviceExtensions ?? EMPTY_SERVICE_EXTENSIONS}
                 />
               </AuthProvider>
             </QueryClientProvider>
@@ -112,6 +116,8 @@ const App = (props: AppProps) => {
   )
 }
 
+type AuroraRouter = ReturnType<typeof createAuroraRouter>
+
 function AppInner({
   router,
   navItems,
@@ -120,16 +126,16 @@ function AppInner({
   appName,
   onTrackEvent,
   enabledServices,
-  additionalProjectServices,
+  serviceExtensions,
 }: {
-  router: ReturnType<typeof createAuroraRouter>
+  router: AuroraRouter
   navItems: NavigationItem[]
   handleThemeToggle: (theme: string) => void
   slots?: Slots
   appName?: string
   onTrackEvent?: OnTrackEventCallback
   enabledServices?: string[]
-  additionalProjectServices: AdditionalProjectService[]
+  serviceExtensions: ServiceExtension[]
 }) {
   const auth = useAuth()
 
@@ -143,7 +149,7 @@ function AppInner({
     appName,
     onTrackEvent,
     enabledServices,
-    additionalProjectServices,
+    serviceExtensions,
   }
 
   // Set up analytics tracking for router navigation

--- a/packages/aurora/src/client/AuroraApp.tsx
+++ b/packages/aurora/src/client/AuroraApp.tsx
@@ -1,5 +1,4 @@
 import type { FC } from "react"
-import type { AnyRoute } from "@tanstack/react-router"
 import type { TrpcClient } from "./trpcClient"
 import App from "./App"
 
@@ -55,13 +54,34 @@ export type TrackEventPayload = {
 export type OnTrackEventCallback = (payload: TrackEventPayload) => void
 
 /**
- * An additional project-scoped service a consumer wants to register.
- * Aurora checks `serviceIndex[serviceType][serviceName]` against the project's OpenStack catalog.
- * When present, the service appears in the "Services" nav section and its routes are activated
- * under the OSS-owned `/services` layout. Pass the service's entry route (list/overview) as
- * `routes` — wire its full sub-tree via `addChildren` and set `getParentRoute: () => servicesRoute`.
+ * Host-provided data handed to a mounted service extension. Extend this as extensions need more
+ * from OSS (domainId, scope, a typed tRPC client, ...). Seed it into the extension's own router
+ * context so pages can read it via `useRouteContext`.
  */
-export type AdditionalProjectService = {
+export type ServiceExtensionContext = {
+  /** The current project ID. */
+  projectId: string
+}
+
+/**
+ * Props passed to a service extension component mounted by OSS.
+ * The basePath is the full URL prefix up to and including the service type segment.
+ */
+export type ServiceExtensionProps = {
+  /** Full URL prefix for this service, e.g. "/projects/abc/services/pca". Pass as `basepath` to RouterProvider. */
+  basePath: string
+  /** Host context to seed into the extension's own router context. */
+  context: ServiceExtensionContext
+}
+
+/**
+ * A project-scoped service extension a consumer wants to register.
+ * Aurora checks `serviceIndex[serviceType][serviceName]` against the project's OpenStack catalog.
+ * When present, the service appears in the "Services" nav section and its component is mounted
+ * under `/projects/$projectId/services/$serviceType`. The component receives `basePath` and
+ * `context`: use these to set up a standalone RouterProvider for the service.
+ */
+export type ServiceExtension = {
   /** OpenStack catalog service type, e.g. `"pca"`. */
   serviceType: string
   /** OpenStack catalog service name, e.g. `"clavis"`. */
@@ -69,12 +89,14 @@ export type AdditionalProjectService = {
   /** Nav item and service card label. */
   label: string
   /**
-   * The pre-assembled entry route for this service (list/overview).
-   * Set `getParentRoute: () => servicesRoute` (from `@cobaltcore-dev/aurora/client`) and wire
-   * the full sub-tree via `addChildren` before passing here.
-   * `routes.fullPath` is used as the nav item navigation target automatically.
+   * The React component to render at `/projects/$projectId/services/$serviceType/**`.
+   * Receives `basePath` (the URL prefix) and `context` (host data). Create your own RouterProvider
+   * inside this component using `basePath` as the `basepath` prop and `context` as the router context.
+   *
+   * Note: this is a self-contained sub-app. Host slots (see `Slots`) are not injected into it, so the
+   * extension owns its own header/actions (e.g. via the re-exported `PageContentHeader` `actions` prop).
    */
-  routes: AnyRoute
+  component: FC<ServiceExtensionProps>
 }
 
 /** Props for the top-level `<AuroraApp />` component. */
@@ -112,8 +134,8 @@ export type AuroraAppProps = {
   onTrackEvent?: OnTrackEventCallback
   /** Whitelist of service keys to show in the side nav and project home page. When omitted, all available services are shown. */
   enabledServices?: string[]
-  /** Additional project-scoped services to register. Each is activated when its OpenStack service appears in the project catalog. */
-  additionalProjectServices?: AdditionalProjectService[]
+  /** Service extensions to register. Each is activated when its OpenStack service appears in the project catalog. */
+  serviceExtensions?: ServiceExtension[]
 }
 
 export const AuroraApp: FC<AuroraAppProps> = App

--- a/packages/aurora/src/client/hooks/useBreadcrumbs.test.tsx
+++ b/packages/aurora/src/client/hooks/useBreadcrumbs.test.tsx
@@ -29,7 +29,7 @@ vi.mock("@tanstack/react-router", () => ({
     },
   ],
   useParams: () => ({ projectId: "test-project" }),
-  useRouteContext: () => ({ additionalProjectServices: [] }),
+  useRouteContext: () => ({ serviceExtensions: [] }),
 }))
 
 const wrapper = ({ children }: { children: ReactNode }) => (

--- a/packages/aurora/src/client/index.ts
+++ b/packages/aurora/src/client/index.ts
@@ -5,7 +5,9 @@ export {
   type SlotProps,
   type TrackEventPayload,
   type OnTrackEventCallback,
-  type AdditionalProjectService,
+  type ServiceExtension,
+  type ServiceExtensionProps,
+  type ServiceExtensionContext,
 } from "./AuroraApp"
 export {
   type TrpcClient,
@@ -18,11 +20,11 @@ export {
 } from "./trpcClient"
 
 export { useAuth } from "./store/AuthProvider"
-export { useDomainId, useProjectId, useScope } from "./hooks"
-export { servicesRoute } from "./routes/_auth/projects/$projectId/services"
+export { useDomainId, useScope } from "./hooks"
 export type { RouteInfo, Crumb } from "./routes/routeInfo"
 export { isRouteInfo } from "./routes/routeInfo"
 export { usePushBreadcrumbs } from "./hooks/usePushBreadcrumbs"
 export { useSetBreadcrumb } from "./hooks/useSetBreadcrumb"
 export { useBreadcrumbs, type BreadcrumbItem } from "./hooks/useBreadcrumbs"
 export { DynamicBreadcrumbContext, DynamicBreadcrumbProvider } from "./context/DynamicBreadcrumbContext"
+export { ContentHeader as PageContentHeader } from "./components/ContentHeader/ContentHeader"

--- a/packages/aurora/src/client/routeTree.gen.ts
+++ b/packages/aurora/src/client/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as AuthProjectsProjectIdNetworkIndexRouteImport } from "./routes/
 import { Route as AuthProjectsProjectIdNetworkFloatingipsRouteImport } from "./routes/_auth/projects/$projectId/network/floatingips"
 import { Route as AuthProjectsProjectIdNetworkSecuritygroupsRouteImport } from "./routes/_auth/projects/$projectId/network/securitygroups"
 import { Route as AuthProjectsProjectIdServicesIndexRouteImport } from "./routes/_auth/projects/$projectId/services/index"
+import { Route as AuthProjectsProjectIdServicesServiceTypeRouteImport } from "./routes/_auth/projects/$projectId/services/$serviceType"
 import { Route as AuthProjectsProjectIdStorageIndexRouteImport } from "./routes/_auth/projects/$projectId/storage/index"
 import { Route as AuthProjectsProjectIdComputeFlavorsIndexRouteImport } from "./routes/_auth/projects/$projectId/compute/flavors/index"
 import { Route as AuthProjectsProjectIdComputeFlavorsFlavorIdRouteImport } from "./routes/_auth/projects/$projectId/compute/flavors/$flavorId"
@@ -33,6 +34,8 @@ import { Route as AuthProjectsProjectIdComputeImagesIndexRouteImport } from "./r
 import { Route as AuthProjectsProjectIdComputeImagesImageIdRouteImport } from "./routes/_auth/projects/$projectId/compute/images/$imageId"
 import { Route as AuthProjectsProjectIdNetworkFloatingipsIndexRouteImport } from "./routes/_auth/projects/$projectId/network/floatingips/index"
 import { Route as AuthProjectsProjectIdNetworkSecuritygroupsIndexRouteImport } from "./routes/_auth/projects/$projectId/network/securitygroups/index"
+import { Route as AuthProjectsProjectIdServicesServiceTypeIndexRouteImport } from "./routes/_auth/projects/$projectId/services/$serviceType/index"
+import { Route as AuthProjectsProjectIdServicesServiceTypeSplatRouteImport } from "./routes/_auth/projects/$projectId/services/$serviceType/$"
 import { Route as AuthProjectsProjectIdStorageProviderStorageTypeRouteImport } from "./routes/_auth/projects/$projectId/storage/$provider/$storageType"
 import { Route as AuthProjectsProjectIdNetworkFloatingipsFloatingIpIdIndexRouteImport } from "./routes/_auth/projects/$projectId/network/floatingips/$floatingIpId/index"
 import { Route as AuthProjectsProjectIdNetworkSecuritygroupsSecurityGroupIdIndexRouteImport } from "./routes/_auth/projects/$projectId/network/securitygroups/$securityGroupId/index"
@@ -133,6 +136,12 @@ const AuthProjectsProjectIdServicesIndexRoute =
     path: "/",
     getParentRoute: () => AuthProjectsProjectIdServicesRoute,
   } as any)
+const AuthProjectsProjectIdServicesServiceTypeRoute =
+  AuthProjectsProjectIdServicesServiceTypeRouteImport.update({
+    id: "/$serviceType",
+    path: "/$serviceType",
+    getParentRoute: () => AuthProjectsProjectIdServicesRoute,
+  } as any)
 const AuthProjectsProjectIdStorageIndexRoute =
   AuthProjectsProjectIdStorageIndexRouteImport.update({
     id: "/storage/",
@@ -174,6 +183,18 @@ const AuthProjectsProjectIdNetworkSecuritygroupsIndexRoute =
     id: "/",
     path: "/",
     getParentRoute: () => AuthProjectsProjectIdNetworkSecuritygroupsRoute,
+  } as any)
+const AuthProjectsProjectIdServicesServiceTypeIndexRoute =
+  AuthProjectsProjectIdServicesServiceTypeIndexRouteImport.update({
+    id: "/",
+    path: "/",
+    getParentRoute: () => AuthProjectsProjectIdServicesServiceTypeRoute,
+  } as any)
+const AuthProjectsProjectIdServicesServiceTypeSplatRoute =
+  AuthProjectsProjectIdServicesServiceTypeSplatRouteImport.update({
+    id: "/$",
+    path: "/$",
+    getParentRoute: () => AuthProjectsProjectIdServicesServiceTypeRoute,
   } as any)
 const AuthProjectsProjectIdStorageProviderStorageTypeRoute =
   AuthProjectsProjectIdStorageProviderStorageTypeRouteImport.update({
@@ -225,17 +246,20 @@ export interface FileRoutesByFullPath {
   "/projects/$projectId/compute/images": typeof AuthProjectsProjectIdComputeImagesRouteWithChildren
   "/projects/$projectId/network/floatingips": typeof AuthProjectsProjectIdNetworkFloatingipsRouteWithChildren
   "/projects/$projectId/network/securitygroups": typeof AuthProjectsProjectIdNetworkSecuritygroupsRouteWithChildren
+  "/projects/$projectId/services/$serviceType": typeof AuthProjectsProjectIdServicesServiceTypeRouteWithChildren
   "/projects/$projectId/compute/": typeof AuthProjectsProjectIdComputeIndexRoute
   "/projects/$projectId/network/": typeof AuthProjectsProjectIdNetworkIndexRoute
   "/projects/$projectId/services/": typeof AuthProjectsProjectIdServicesIndexRoute
   "/projects/$projectId/storage/": typeof AuthProjectsProjectIdStorageIndexRoute
   "/projects/$projectId/compute/flavors/$flavorId": typeof AuthProjectsProjectIdComputeFlavorsFlavorIdRoute
   "/projects/$projectId/compute/images/$imageId": typeof AuthProjectsProjectIdComputeImagesImageIdRoute
+  "/projects/$projectId/services/$serviceType/$": typeof AuthProjectsProjectIdServicesServiceTypeSplatRoute
   "/projects/$projectId/storage/$provider/$storageType": typeof AuthProjectsProjectIdStorageProviderStorageTypeRouteWithChildren
   "/projects/$projectId/compute/flavors/": typeof AuthProjectsProjectIdComputeFlavorsIndexRoute
   "/projects/$projectId/compute/images/": typeof AuthProjectsProjectIdComputeImagesIndexRoute
   "/projects/$projectId/network/floatingips/": typeof AuthProjectsProjectIdNetworkFloatingipsIndexRoute
   "/projects/$projectId/network/securitygroups/": typeof AuthProjectsProjectIdNetworkSecuritygroupsIndexRoute
+  "/projects/$projectId/services/$serviceType/": typeof AuthProjectsProjectIdServicesServiceTypeIndexRoute
   "/projects/$projectId/network/floatingips/$floatingIpId/": typeof AuthProjectsProjectIdNetworkFloatingipsFloatingIpIdIndexRoute
   "/projects/$projectId/network/securitygroups/$securityGroupId/": typeof AuthProjectsProjectIdNetworkSecuritygroupsSecurityGroupIdIndexRoute
   "/projects/$projectId/storage/$provider/$storageType/": typeof AuthProjectsProjectIdStorageProviderStorageTypeIndexRoute
@@ -254,10 +278,12 @@ export interface FileRoutesByTo {
   "/projects/$projectId/storage": typeof AuthProjectsProjectIdStorageIndexRoute
   "/projects/$projectId/compute/flavors/$flavorId": typeof AuthProjectsProjectIdComputeFlavorsFlavorIdRoute
   "/projects/$projectId/compute/images/$imageId": typeof AuthProjectsProjectIdComputeImagesImageIdRoute
+  "/projects/$projectId/services/$serviceType/$": typeof AuthProjectsProjectIdServicesServiceTypeSplatRoute
   "/projects/$projectId/compute/flavors": typeof AuthProjectsProjectIdComputeFlavorsIndexRoute
   "/projects/$projectId/compute/images": typeof AuthProjectsProjectIdComputeImagesIndexRoute
   "/projects/$projectId/network/floatingips": typeof AuthProjectsProjectIdNetworkFloatingipsIndexRoute
   "/projects/$projectId/network/securitygroups": typeof AuthProjectsProjectIdNetworkSecuritygroupsIndexRoute
+  "/projects/$projectId/services/$serviceType": typeof AuthProjectsProjectIdServicesServiceTypeIndexRoute
   "/projects/$projectId/network/floatingips/$floatingIpId": typeof AuthProjectsProjectIdNetworkFloatingipsFloatingIpIdIndexRoute
   "/projects/$projectId/network/securitygroups/$securityGroupId": typeof AuthProjectsProjectIdNetworkSecuritygroupsSecurityGroupIdIndexRoute
   "/projects/$projectId/storage/$provider/$storageType": typeof AuthProjectsProjectIdStorageProviderStorageTypeIndexRoute
@@ -279,17 +305,20 @@ export interface FileRoutesById {
   "/_auth/projects/$projectId/compute/images": typeof AuthProjectsProjectIdComputeImagesRouteWithChildren
   "/_auth/projects/$projectId/network/floatingips": typeof AuthProjectsProjectIdNetworkFloatingipsRouteWithChildren
   "/_auth/projects/$projectId/network/securitygroups": typeof AuthProjectsProjectIdNetworkSecuritygroupsRouteWithChildren
+  "/_auth/projects/$projectId/services/$serviceType": typeof AuthProjectsProjectIdServicesServiceTypeRouteWithChildren
   "/_auth/projects/$projectId/compute/": typeof AuthProjectsProjectIdComputeIndexRoute
   "/_auth/projects/$projectId/network/": typeof AuthProjectsProjectIdNetworkIndexRoute
   "/_auth/projects/$projectId/services/": typeof AuthProjectsProjectIdServicesIndexRoute
   "/_auth/projects/$projectId/storage/": typeof AuthProjectsProjectIdStorageIndexRoute
   "/_auth/projects/$projectId/compute/flavors/$flavorId": typeof AuthProjectsProjectIdComputeFlavorsFlavorIdRoute
   "/_auth/projects/$projectId/compute/images/$imageId": typeof AuthProjectsProjectIdComputeImagesImageIdRoute
+  "/_auth/projects/$projectId/services/$serviceType/$": typeof AuthProjectsProjectIdServicesServiceTypeSplatRoute
   "/_auth/projects/$projectId/storage/$provider/$storageType": typeof AuthProjectsProjectIdStorageProviderStorageTypeRouteWithChildren
   "/_auth/projects/$projectId/compute/flavors/": typeof AuthProjectsProjectIdComputeFlavorsIndexRoute
   "/_auth/projects/$projectId/compute/images/": typeof AuthProjectsProjectIdComputeImagesIndexRoute
   "/_auth/projects/$projectId/network/floatingips/": typeof AuthProjectsProjectIdNetworkFloatingipsIndexRoute
   "/_auth/projects/$projectId/network/securitygroups/": typeof AuthProjectsProjectIdNetworkSecuritygroupsIndexRoute
+  "/_auth/projects/$projectId/services/$serviceType/": typeof AuthProjectsProjectIdServicesServiceTypeIndexRoute
   "/_auth/projects/$projectId/network/floatingips/$floatingIpId/": typeof AuthProjectsProjectIdNetworkFloatingipsFloatingIpIdIndexRoute
   "/_auth/projects/$projectId/network/securitygroups/$securityGroupId/": typeof AuthProjectsProjectIdNetworkSecuritygroupsSecurityGroupIdIndexRoute
   "/_auth/projects/$projectId/storage/$provider/$storageType/": typeof AuthProjectsProjectIdStorageProviderStorageTypeIndexRoute
@@ -311,17 +340,20 @@ export interface FileRouteTypes {
     | "/projects/$projectId/compute/images"
     | "/projects/$projectId/network/floatingips"
     | "/projects/$projectId/network/securitygroups"
+    | "/projects/$projectId/services/$serviceType"
     | "/projects/$projectId/compute/"
     | "/projects/$projectId/network/"
     | "/projects/$projectId/services/"
     | "/projects/$projectId/storage/"
     | "/projects/$projectId/compute/flavors/$flavorId"
     | "/projects/$projectId/compute/images/$imageId"
+    | "/projects/$projectId/services/$serviceType/$"
     | "/projects/$projectId/storage/$provider/$storageType"
     | "/projects/$projectId/compute/flavors/"
     | "/projects/$projectId/compute/images/"
     | "/projects/$projectId/network/floatingips/"
     | "/projects/$projectId/network/securitygroups/"
+    | "/projects/$projectId/services/$serviceType/"
     | "/projects/$projectId/network/floatingips/$floatingIpId/"
     | "/projects/$projectId/network/securitygroups/$securityGroupId/"
     | "/projects/$projectId/storage/$provider/$storageType/"
@@ -340,10 +372,12 @@ export interface FileRouteTypes {
     | "/projects/$projectId/storage"
     | "/projects/$projectId/compute/flavors/$flavorId"
     | "/projects/$projectId/compute/images/$imageId"
+    | "/projects/$projectId/services/$serviceType/$"
     | "/projects/$projectId/compute/flavors"
     | "/projects/$projectId/compute/images"
     | "/projects/$projectId/network/floatingips"
     | "/projects/$projectId/network/securitygroups"
+    | "/projects/$projectId/services/$serviceType"
     | "/projects/$projectId/network/floatingips/$floatingIpId"
     | "/projects/$projectId/network/securitygroups/$securityGroupId"
     | "/projects/$projectId/storage/$provider/$storageType"
@@ -364,17 +398,20 @@ export interface FileRouteTypes {
     | "/_auth/projects/$projectId/compute/images"
     | "/_auth/projects/$projectId/network/floatingips"
     | "/_auth/projects/$projectId/network/securitygroups"
+    | "/_auth/projects/$projectId/services/$serviceType"
     | "/_auth/projects/$projectId/compute/"
     | "/_auth/projects/$projectId/network/"
     | "/_auth/projects/$projectId/services/"
     | "/_auth/projects/$projectId/storage/"
     | "/_auth/projects/$projectId/compute/flavors/$flavorId"
     | "/_auth/projects/$projectId/compute/images/$imageId"
+    | "/_auth/projects/$projectId/services/$serviceType/$"
     | "/_auth/projects/$projectId/storage/$provider/$storageType"
     | "/_auth/projects/$projectId/compute/flavors/"
     | "/_auth/projects/$projectId/compute/images/"
     | "/_auth/projects/$projectId/network/floatingips/"
     | "/_auth/projects/$projectId/network/securitygroups/"
+    | "/_auth/projects/$projectId/services/$serviceType/"
     | "/_auth/projects/$projectId/network/floatingips/$floatingIpId/"
     | "/_auth/projects/$projectId/network/securitygroups/$securityGroupId/"
     | "/_auth/projects/$projectId/storage/$provider/$storageType/"
@@ -508,6 +545,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof AuthProjectsProjectIdServicesIndexRouteImport
       parentRoute: typeof AuthProjectsProjectIdServicesRoute
     }
+    "/_auth/projects/$projectId/services/$serviceType": {
+      id: "/_auth/projects/$projectId/services/$serviceType"
+      path: "/$serviceType"
+      fullPath: "/projects/$projectId/services/$serviceType"
+      preLoaderRoute: typeof AuthProjectsProjectIdServicesServiceTypeRouteImport
+      parentRoute: typeof AuthProjectsProjectIdServicesRoute
+    }
     "/_auth/projects/$projectId/storage/": {
       id: "/_auth/projects/$projectId/storage/"
       path: "/storage"
@@ -556,6 +600,20 @@ declare module "@tanstack/react-router" {
       fullPath: "/projects/$projectId/network/securitygroups/"
       preLoaderRoute: typeof AuthProjectsProjectIdNetworkSecuritygroupsIndexRouteImport
       parentRoute: typeof AuthProjectsProjectIdNetworkSecuritygroupsRoute
+    }
+    "/_auth/projects/$projectId/services/$serviceType/": {
+      id: "/_auth/projects/$projectId/services/$serviceType/"
+      path: "/"
+      fullPath: "/projects/$projectId/services/$serviceType/"
+      preLoaderRoute: typeof AuthProjectsProjectIdServicesServiceTypeIndexRouteImport
+      parentRoute: typeof AuthProjectsProjectIdServicesServiceTypeRoute
+    }
+    "/_auth/projects/$projectId/services/$serviceType/$": {
+      id: "/_auth/projects/$projectId/services/$serviceType/$"
+      path: "/$"
+      fullPath: "/projects/$projectId/services/$serviceType/$"
+      preLoaderRoute: typeof AuthProjectsProjectIdServicesServiceTypeSplatRouteImport
+      parentRoute: typeof AuthProjectsProjectIdServicesServiceTypeRoute
     }
     "/_auth/projects/$projectId/storage/$provider/$storageType": {
       id: "/_auth/projects/$projectId/storage/$provider/$storageType"
@@ -652,12 +710,33 @@ const AuthProjectsProjectIdNetworkRouteWithChildren =
     AuthProjectsProjectIdNetworkRouteChildren,
   )
 
+interface AuthProjectsProjectIdServicesServiceTypeRouteChildren {
+  AuthProjectsProjectIdServicesServiceTypeSplatRoute: typeof AuthProjectsProjectIdServicesServiceTypeSplatRoute
+  AuthProjectsProjectIdServicesServiceTypeIndexRoute: typeof AuthProjectsProjectIdServicesServiceTypeIndexRoute
+}
+
+const AuthProjectsProjectIdServicesServiceTypeRouteChildren: AuthProjectsProjectIdServicesServiceTypeRouteChildren =
+  {
+    AuthProjectsProjectIdServicesServiceTypeSplatRoute:
+      AuthProjectsProjectIdServicesServiceTypeSplatRoute,
+    AuthProjectsProjectIdServicesServiceTypeIndexRoute:
+      AuthProjectsProjectIdServicesServiceTypeIndexRoute,
+  }
+
+const AuthProjectsProjectIdServicesServiceTypeRouteWithChildren =
+  AuthProjectsProjectIdServicesServiceTypeRoute._addFileChildren(
+    AuthProjectsProjectIdServicesServiceTypeRouteChildren,
+  )
+
 interface AuthProjectsProjectIdServicesRouteChildren {
+  AuthProjectsProjectIdServicesServiceTypeRoute: typeof AuthProjectsProjectIdServicesServiceTypeRouteWithChildren
   AuthProjectsProjectIdServicesIndexRoute: typeof AuthProjectsProjectIdServicesIndexRoute
 }
 
 const AuthProjectsProjectIdServicesRouteChildren: AuthProjectsProjectIdServicesRouteChildren =
   {
+    AuthProjectsProjectIdServicesServiceTypeRoute:
+      AuthProjectsProjectIdServicesServiceTypeRouteWithChildren,
     AuthProjectsProjectIdServicesIndexRoute:
       AuthProjectsProjectIdServicesIndexRoute,
   }

--- a/packages/aurora/src/client/router.ts
+++ b/packages/aurora/src/client/router.ts
@@ -1,34 +1,13 @@
 import { createRouter } from "@tanstack/react-router"
 import { routeTree } from "./routeTree.gen"
 import type { TrpcReact, TrpcClient } from "./trpcClient"
-import type { AdditionalProjectService } from "./AuroraApp"
-import type { AnyRoute } from "@tanstack/react-router"
-
-type RouteWithChildren = {
-  _addFileChildren: (c: Record<string, AnyRoute>) => void
-  children?: Record<string, AnyRoute>
-}
+import type { ServiceExtension } from "./AuroraApp"
 
 export function createAuroraRouter(
   trpcReact: TrpcReact,
   trpcClient: TrpcClient,
-  additionalProjectServices?: AdditionalProjectService[]
+  serviceExtensions?: ServiceExtension[]
 ) {
-  const extraRoutes = additionalProjectServices?.map((m) => m.routes) ?? []
-
-  if (extraRoutes.length > 0) {
-    for (let i = 0; i < extraRoutes.length; i++) {
-      const route = extraRoutes[i]
-      const parentFn = (route as { options?: { getParentRoute?: () => AnyRoute } }).options?.getParentRoute
-      if (!parentFn) {
-        throw new Error(`additionalProjectServices[${i}] route is missing options.getParentRoute()`)
-      }
-      const parent = parentFn() as unknown as RouteWithChildren
-      const existing = parent.children ?? {}
-      parent._addFileChildren({ ...existing, [`_extra_${i}`]: route })
-    }
-  }
-
   return createRouter({
     routeTree,
     context: {
@@ -39,7 +18,7 @@ export function createAuroraRouter(
       handleThemeToggle: undefined!,
       slots: undefined,
       onTrackEvent: undefined,
-      additionalProjectServices: additionalProjectServices ?? [],
+      serviceExtensions: serviceExtensions ?? [],
     },
   })
 }

--- a/packages/aurora/src/client/routes/__root.tsx
+++ b/packages/aurora/src/client/routes/__root.tsx
@@ -4,7 +4,7 @@ import { MainNavigation } from "../components/navigation/MainNavigation"
 import { TrpcClient, TrpcReact } from "../trpcClient"
 import { AuthContext } from "../store/AuthProvider"
 import { NavigationItem } from "../components/navigation/types"
-import type { Slots, OnTrackEventCallback, AdditionalProjectService } from "../AuroraApp"
+import type { Slots, OnTrackEventCallback, ServiceExtension } from "../AuroraApp"
 import styles from "../index.css?inline"
 import { RouteError } from "../components/Error/RouteError"
 import { TRPCClientError } from "@trpc/client"
@@ -21,7 +21,7 @@ export interface RouterContext {
   appName?: string
   onTrackEvent?: OnTrackEventCallback
   enabledServices?: string[]
-  additionalProjectServices: AdditionalProjectService[]
+  serviceExtensions: ServiceExtension[]
 }
 
 export const Route = createRootRouteWithContext<RouterContext>()({

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId.tsx
@@ -100,7 +100,7 @@ function RouteComponent() {
   const { t } = useLingui()
   const loaderData = useLoaderData({ from: Route.id })
   const navigate = Route.useNavigate()
-  const { enabledServices, additionalProjectServices } = useRouteContext({ strict: false })
+  const { enabledServices, serviceExtensions } = useRouteContext({ strict: false })
 
   const projectName = loaderData.crumbProject?.name || loaderData.projectId
   const projectLabel = loaderData.crumbDomain?.name ? `${loaderData.crumbDomain.name}/${projectName}` : projectName
@@ -175,8 +175,8 @@ function RouteComponent() {
   const { availableServices, projectId, crumbProject, crumbDomain } = loaderData
 
   const sections = useMemo(
-    () => buildNavSections(projectId, availableServices!, enabledServices, additionalProjectServices),
-    [projectId, availableServices, enabledServices, additionalProjectServices]
+    () => buildNavSections(projectId, availableServices!, enabledServices, serviceExtensions),
+    [projectId, availableServices, enabledServices, serviceExtensions]
   )
 
   return (

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/index.tsx
@@ -56,7 +56,7 @@ function RouteComponent() {
     from: "/_auth/projects/$projectId",
   })
   const { t } = useLingui()
-  const { enabledServices, additionalProjectServices } = useRouteContext({ strict: false })
+  const { enabledServices, serviceExtensions } = useRouteContext({ strict: false })
   const isEnabled = (service: string) => !enabledServices || enabledServices.includes(service)
 
   const serviceIndex = getServiceIndex(availableServices ?? [])
@@ -99,17 +99,17 @@ function RouteComponent() {
       service: "ceph-containers",
     })
 
-  for (const additionalService of additionalProjectServices ?? []) {
-    // if additional service is in the list of services and is enabled display a card for it
+  for (const extension of serviceExtensions ?? []) {
+    // if the extension's service is in the catalog and enabled, display a card for it
     if (
-      serviceIndex[additionalService.serviceType]?.[additionalService.serviceName] &&
-      (!enabledServices || enabledServices.includes(additionalService.serviceType))
+      serviceIndex[extension.serviceType]?.[extension.serviceName] &&
+      (!enabledServices || enabledServices.includes(extension.serviceType))
     )
       cards.push({
         group: t`Services`,
-        label: additionalService.label,
-        to: additionalService.routes.fullPath.replace("$projectId", projectId),
-        service: additionalService.serviceType,
+        label: extension.label,
+        to: `/projects/${projectId}/services/${extension.serviceType}`,
+        service: extension.serviceType,
       })
   }
 

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/services/$serviceType.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/services/$serviceType.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute, notFound } from "@tanstack/react-router"
+import { ServiceExtensionMount } from "./$serviceType/-components/ServiceExtensionMount"
+
+// Render the extension mount at the layout level so it stays mounted across all
+// /services/$serviceType/** navigation. The index and splat child routes exist only to
+// match the URL (so deep links don't 404); if the mount rendered in those children instead,
+// navigating between them would tear down and rebuild the extension's own RouterProvider,
+// losing its state, scroll position, and in-flight fetches.
+export const Route = createFileRoute("/_auth/projects/$projectId/services/$serviceType")({
+  staticData: { section: "services" },
+  // notFound() must be thrown from a loader, not during render, for TanStack Router to
+  // intercept it and show notFoundComponent rather than crashing the error boundary.
+  loader: ({ context, params }) => {
+    if (!context.serviceExtensions.some((s) => s.serviceType === params.serviceType)) throw notFound()
+  },
+  component: ServiceExtensionMount,
+})

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/services/$serviceType/$.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/services/$serviceType/$.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+// Catch-all so deep links under /services/$serviceType/** match (no 404). The extension mount
+// is rendered by the parent layout route ($serviceType.tsx) so it persists across navigation;
+// the extension's own router handles everything below the base path.
+export const Route = createFileRoute("/_auth/projects/$projectId/services/$serviceType/$")({
+  component: () => null,
+})

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/services/$serviceType/-components/ServiceExtensionMount.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/services/$serviceType/-components/ServiceExtensionMount.tsx
@@ -1,0 +1,23 @@
+import { useMemo } from "react"
+import { useParams, useRouteContext } from "@tanstack/react-router"
+import type { ServiceExtensionContext } from "@/client/AuroraApp"
+
+/**
+ * Looks up the registered service extension for the current $serviceType URL param
+ * and renders its component with the correct basePath and host context.
+ */
+export function ServiceExtensionMount() {
+  const { projectId, serviceType } = useParams({ strict: false }) as { projectId: string; serviceType: string }
+  const { serviceExtensions } = useRouteContext({ strict: false })
+  const extension = serviceExtensions?.find((s) => s.serviceType === serviceType)
+
+  // Memoize so the object reference stays stable across renders and the extension's own
+  // createRouter (seeded with this context) is not recreated on every render.
+  const context = useMemo<ServiceExtensionContext>(() => ({ projectId }), [projectId])
+
+  if (!extension?.component) return null
+
+  const basePath = `/projects/${projectId}/services/${serviceType}`
+  const ServiceComponent = extension.component
+  return <ServiceComponent basePath={basePath} context={context} />
+}

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/services/$serviceType/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/services/$serviceType/index.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+// Exists only so the exact /services/$serviceType path matches. The extension mount is
+// rendered by the parent layout route ($serviceType.tsx) so it persists across navigation.
+export const Route = createFileRoute("/_auth/projects/$projectId/services/$serviceType/")({
+  component: () => null,
+})

--- a/packages/aurora/src/client/routes/_auth/projects/-components/SideNavBar.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/-components/SideNavBar.tsx
@@ -21,7 +21,7 @@ interface SideNavBarProps {
 export const SideNavBar = ({ projectId, projectName, domainName, sections }: SideNavBarProps) => {
   const navigate = useNavigate()
   const matches = useMatches()
-  const { provider } = useParams({ strict: false }) as { provider?: string }
+  const { provider, serviceType } = useParams({ strict: false }) as { provider?: string; serviceType?: string }
   const { slots } = useRouteContext({ strict: false })
 
   const navBadge = (service: string) => {
@@ -29,11 +29,19 @@ export const SideNavBar = ({ projectId, projectName, domainName, sections }: Sid
     return <Slot component={slots.serviceBadge} useShadowDOM={false} currentService={service} />
   }
 
-  // Read active section/service from the deepest match that has valid RouteInfo staticData
-  const activeMatch = [...matches].reverse().find((m) => isRouteInfo(m.staticData))
+  // Read active section/service from the deepest match that has meaningful RouteInfo staticData.
+  // isRouteInfo uses an all-optional schema, so an empty {} also passes — require at least section
+  // or service to be set so that stub routes (index/splat) don't shadow their layout parent.
+  const activeMatch = [...matches]
+    .reverse()
+    .find(
+      (m) => isRouteInfo(m.staticData) && (m.staticData.section !== undefined || m.staticData.service !== undefined)
+    )
   const activeRouteInfo = activeMatch && isRouteInfo(activeMatch.staticData) ? activeMatch.staticData : undefined
   const activeSection = activeRouteInfo?.section ?? null
-  const activeService = activeRouteInfo?.service ?? null
+  // Extension mount routes carry only staticData.section (no static `service`), so fall back to
+  // the $serviceType URL param to identify the active service and highlight its nav item.
+  const activeService = activeRouteInfo?.service ?? serviceType ?? null
 
   // Track which sections should be forced open by incrementing a counter
   // This forces a remount of SideNavigationGroup since it doesn't expose onToggle

--- a/packages/aurora/src/client/routes/_auth/projects/-components/buildNavSections.test.ts
+++ b/packages/aurora/src/client/routes/_auth/projects/-components/buildNavSections.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeAll } from "vitest"
 import { i18n } from "@lingui/core"
 import { buildNavSections } from "./buildNavSections"
-import type { AdditionalProjectService } from "@/client/AuroraApp"
-import type { AnyRoute } from "@tanstack/react-router"
+import type { ServiceExtension } from "@/client/AuroraApp"
 
 beforeAll(() => {
   i18n.load({ en: {} })
@@ -17,11 +16,11 @@ const ALL_SERVICES = [
   { type: "object-store-ceph", name: "ceph" },
 ]
 
-const CUSTOM_SERVICE: AdditionalProjectService = {
+const CUSTOM_SERVICE: ServiceExtension = {
   serviceType: "custom-service",
   serviceName: "custom-provider",
   label: "Custom Service",
-  routes: {} as unknown as AnyRoute,
+  component: () => null,
 }
 
 describe("buildNavSections", () => {
@@ -67,7 +66,7 @@ describe("buildNavSections", () => {
     }
   })
 
-  describe("additionalProjectServices", () => {
+  describe("serviceExtensions", () => {
     it("adds a service nav item in the services section when its service is in the catalog", () => {
       const services = [...ALL_SERVICES, { type: "custom-service", name: "custom-provider" }]
       const sections = buildNavSections("proj-1", services, undefined, [CUSTOM_SERVICE])

--- a/packages/aurora/src/client/routes/_auth/projects/-components/buildNavSections.ts
+++ b/packages/aurora/src/client/routes/_auth/projects/-components/buildNavSections.ts
@@ -1,7 +1,7 @@
 import { getServiceIndex } from "@/server/Authentication/helpers"
 import { t } from "@lingui/core/macro"
 import type { NavigateFn } from "@tanstack/react-router"
-import type { AdditionalProjectService } from "@/client/AuroraApp"
+import type { ServiceExtension } from "@/client/AuroraApp"
 
 export type NavItem = {
   service: string
@@ -20,7 +20,7 @@ export function buildNavSections(
   projectId: string,
   availableServices: { type: string; name: string }[],
   enabledServices?: string[],
-  additionalProjectServices?: AdditionalProjectService[]
+  serviceExtensions?: ServiceExtension[]
 ): NavSection[] {
   const serviceIndex = getServiceIndex(availableServices)
   const isEnabled = (service: string) => !enabledServices || enabledServices.includes(service)
@@ -114,16 +114,20 @@ export function buildNavSections(
     ["services", { section: "services", label: t`Services`, services: [] }],
   ])
 
-  // Merge additional services: activate when the service exists in the project's catalog
-  for (const module of additionalProjectServices ?? []) {
-    if (!serviceIndex[module.serviceType]?.[module.serviceName]) continue
-    if (enabledServices && !enabledServices.includes(module.serviceType)) continue
+  // Merge service extensions: activate when the service exists in the project's catalog
+  for (const extension of serviceExtensions ?? []) {
+    if (!serviceIndex[extension.serviceType]?.[extension.serviceName]) continue
+    if (enabledServices && !enabledServices.includes(extension.serviceType)) continue
 
     sectionMap.get("services")?.services.push({
-      service: module.serviceType,
-      label: module.label,
-      navigate: (nav: NavigateFn) => nav({ to: module.routes.fullPath as never, params: { projectId } as never }),
-      params: { projectId },
+      service: extension.serviceType,
+      label: extension.label,
+      navigate: (nav: NavigateFn) =>
+        nav({
+          to: "/projects/$projectId/services/$serviceType",
+          params: { projectId, serviceType: extension.serviceType },
+        }),
+      params: { projectId, serviceType: extension.serviceType },
     })
   }
 


### PR DESCRIPTION
# Summary

Replaces the route-injection integration for consumer services with a standalone **extension sub-app pattern**, and unifies the registration vocabulary on "extension". Instead of injecting routes into the OSS route tree, a consumer now registers a self-contained React component that Aurora mounts under `/projects/$projectId/services/$serviceType/**`. The component spins up its own `RouterProvider` and receives host data (`projectId`) through an extensible `context` object rather than a shared React context.

# Changes Made

- Renamed the registration API: `AdditionalProjectService` -> `ServiceExtension`, and the `AuroraApp` prop `additionalProjectServices` -> `serviceExtensions`.
- Replaced `ServiceExtension.routes` (`AnyRoute`) with `component` (`FC<ServiceExtensionProps>`): a standalone sub-app that mounts its own TanStack Router via `RouterProvider basepath={basePath}`.
- Reshaped the mount contract to `ServiceExtensionProps = { basePath, context }`, where `context` is an extensible `ServiceExtensionContext` (currently `{ projectId }`). The extension seeds it into its own router context (`createRouter({ routeTree, context })`) and reads it via `useRouteContext`, so future host fields (domainId, scope, etc.) can be added without changing the component signature.
- Removed `useProjectId` and `servicesRoute` from the public API; consumers no longer inject routes or depend on a shared projectId hook/context.
- Added new exports: `ServiceExtension`, `ServiceExtensionProps`, `ServiceExtensionContext`, and `PageContentHeader` (re-exported `ContentHeader`) so extensions can render an OSS-styled page header with their own actions.
- OSS mounts the extension at the `$serviceType` layout route so it persists across sub-navigation; the `index` and splat routes only match URLs. Nav highlighting falls back to the `$serviceType` URL param since extension mount routes carry no static `service`.
- On `/services/$serviceType/**` routes, no section crumb is shown (consistent with compute/network/storage); the extension owns every crumb below the service level via `usePushBreadcrumbs`.
- Documented the design decision that host slots are **not** injected into extension sub-apps (extensions own their own header/actions), and updated the README "Service extensions" section to the new API.
- Small hardening: stable empty-array reference for the "no extensions" case to preserve the `buildNavSections` memoization.

# Related Issues

- Issue: #1253 

# Screenshots (if applicable)

N/A (no user-visible change; projectId resolves identically inside mounted extensions).

# Testing Instructions

1. `pnpm i`
2. `pnpm --filter @cobaltcore-dev/aurora typecheck && pnpm --filter @cobaltcore-dev/aurora lint && pnpm --filter @cobaltcore-dev/aurora test`
3. Rebuild and install OSS into the SCI dashboard, then `pnpm --filter dashboard typecheck`.
4. In the SCI dashboard, open `/projects/$projectId/services/pca`: the list loads (projectId-scoped query works) and the breadcrumb reads `Home -> monsoon3/cc-demo -> PCA (Clavis)`.
5. Open a PCA detail page and a modal to confirm the seeded `projectId` still resolves in deep, non-route components.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
