### PR TITLE
fix(deps): resolve tmp path traversal vulnerability via pnpm override

### DIFF
--- a/.changeset/fix-tmp-vulnerability.md
+++ b/.changeset/fix-tmp-vulnerability.md
@@ -1,0 +1,7 @@
+---
+"@cobaltcore-dev/aurora-dashboard": patch
+---
+
+fix: resolve tmp path traversal vulnerability (CVE) via pnpm override
+
+Override transitive dependency `tmp@<0.2.6` to `>=0.2.6` to fix a path traversal vulnerability that allows escaping the temporary directory via unsanitized prefix/postfix options. The vulnerable version was pulled in through `cz-customizable → inquirer → external-editor → tmp@0.0.33`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@fastify/static@<10.1.2': ^10.1.2
+  tmp@<0.2.6: '>=0.2.6'
 
 importers:
 
@@ -4399,10 +4400,6 @@ packages:
     resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==}
     engines: {node: '>=0.10.0'}
 
-  os-tmpdir@1.0.2:
-    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
-    engines: {node: '>=0.10.0'}
-
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
@@ -5181,9 +5178,9 @@ packages:
     resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
     hasBin: true
 
-  tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
-    engines: {node: '>=0.6.0'}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -8819,7 +8816,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.0.33
+      tmp: 0.2.7
 
   fast-decode-uri-component@1.0.1: {}
 
@@ -9866,8 +9863,6 @@ snapshots:
 
   os-homedir@1.0.2: {}
 
-  os-tmpdir@1.0.2: {}
-
   outdent@0.5.0: {}
 
   own-keys@1.0.2:
@@ -10639,9 +10634,7 @@ snapshots:
     dependencies:
       tldts-core: 7.4.10
 
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
+  tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,3 +15,4 @@ minimumReleaseAgeExclude:
 
 overrides:
   "@fastify/static@<10.1.2": ^10.1.2
+  "tmp@<0.2.6": ">=0.2.6"


### PR DESCRIPTION
## Summary

Fixes the path traversal vulnerability in the `tmp` npm package (CVE) by adding a pnpm override.

## Problem

The `tmp` package (v0.0.33) has a path traversal vulnerability that allows escaping the intended temporary directory when untrusted data flows into the `prefix`, `postfix`, or `dir` options.

**Dependency chain:**
```
cz-customizable → inquirer → external-editor → tmp@0.0.33
```

Dependabot could not auto-fix this because `external-editor` (last updated 2019) still pins `tmp@^0.0.33`.

## Solution

Added a pnpm override in `pnpm-workspace.yaml`:
```yaml
overrides:
  "tmp@<0.2.6": ">=0.2.6"
```

This forces all transitive `tmp` dependencies to use the patched version (0.2.7).

## Verification

- ✅ `pnpm why tmp` shows `tmp@0.2.7`
- ✅ `cz-customizable` still loads correctly
- ✅ Lint and typecheck pass