### PR TITLE
fix(aurora): time doesn't match current timezone (#1236)

### DIFF
--- a/.changeset/common-owls-relax.md
+++ b/.changeset/common-owls-relax.md
@@ -1,0 +1,8 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Swift: container and object "last modified" times now render in the viewer's
+local timezone. Swift returns these timestamps as UTC without a zone
+designator, which were previously parsed as local time and shown with an
+offset.

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/ContainerTableView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/ContainerTableView.tsx
@@ -14,6 +14,7 @@ import {
 import { Trans, useLingui } from "@lingui/react/macro"
 import { ContainerSummary } from "@/server/Storage/types/swift"
 import { formatBytesBinary } from "@/client/utils/formatBytes"
+import { formatSwiftDate } from "@/client/utils/formatSwiftDate"
 import { useVirtualizedTableBody } from "@/client/hooks/useVirtualizedTableBody"
 import { CreateContainerModal } from "./CreateContainerModal"
 import { EmptyContainerModal } from "./EmptyContainerModal"
@@ -94,16 +95,6 @@ export const ContainerTableView = ({
       setScrollbarWidth(width)
     }
   }, [containers.length, bodyHeight])
-
-  // Format date to localized string
-  const formatDate = (dateString: string): string => {
-    try {
-      const date = new Date(dateString)
-      return date.toLocaleString()
-    } catch {
-      return t`N/A`
-    }
-  }
 
   const handleSelectContainer = (containerName: string) => {
     if (selectedContainers.includes(containerName)) {
@@ -238,7 +229,7 @@ export const ContainerTableView = ({
                     </span>
                   </DataGridCell>
                   <DataGridCell>{container.count.toLocaleString()}</DataGridCell>
-                  <DataGridCell>{container.last_modified ? formatDate(container.last_modified) : t`N/A`}</DataGridCell>
+                  <DataGridCell>{formatSwiftDate(container.last_modified) ?? t`N/A`}</DataGridCell>
                   <DataGridCell>{formatBytesBinary(container.bytes)}</DataGridCell>
                   <DataGridCell onClick={(e) => e.stopPropagation()}>
                     <PopupMenu>

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/index.tsx
@@ -194,15 +194,19 @@ export const SwiftContainers = () => {
         case "bytes":
           comparison = a.bytes - b.bytes
           break
-        case "last_modified":
+        case "last_modified": {
           if (!a.last_modified || !b.last_modified) {
             return a.last_modified ? -1 : 1
           }
           // #1236: Swift listing timestamps are UTC without a "Z" — parse them as
-          // UTC so the ordering is correct (matters near DST boundaries).
-          comparison =
-            (parseSwiftDate(a.last_modified)?.getTime() ?? 0) - (parseSwiftDate(b.last_modified)?.getTime() ?? 0)
+          // UTC so the ordering is correct (matters near DST boundaries). If a
+          // (non-empty) value can't be parsed, treat the pair as equal so the
+          // order is left untouched (matches the old NaN behaviour).
+          const at = parseSwiftDate(a.last_modified)?.getTime()
+          const bt = parseSwiftDate(b.last_modified)?.getTime()
+          comparison = at == null || bt == null ? 0 : at - bt
           break
+        }
         default:
           comparison = a.name.localeCompare(b.name)
       }

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/index.tsx
@@ -19,6 +19,7 @@ import {
   toast,
 } from "@cloudoperators/juno-ui-components"
 import { formatBytesBinary } from "@/client/utils/formatBytes"
+import { parseSwiftDate } from "@/client/utils/formatSwiftDate"
 import { ContainerTableView } from "./ContainerTableView"
 import {
   getContainerCreatedToast,
@@ -197,7 +198,10 @@ export const SwiftContainers = () => {
           if (!a.last_modified || !b.last_modified) {
             return a.last_modified ? -1 : 1
           }
-          comparison = new Date(a.last_modified).getTime() - new Date(b.last_modified).getTime()
+          // #1236: Swift listing timestamps are UTC without a "Z" — parse them as
+          // UTC so the ordering is correct (matters near DST boundaries).
+          comparison =
+            (parseSwiftDate(a.last_modified)?.getTime() ?? 0) - (parseSwiftDate(b.last_modified)?.getTime() ?? 0)
           break
         default:
           comparison = a.name.localeCompare(b.name)
@@ -226,7 +230,10 @@ export const SwiftContainers = () => {
 
   const handleSortChange = (newSortSettings: SortSettings) => {
     const resolvedSortBy = (newSortSettings.sortBy?.toString() || "name") as
-      "name" | "count" | "bytes" | "last_modified"
+      | "name"
+      | "count"
+      | "bytes"
+      | "last_modified"
     const resolvedDirection = (newSortSettings.sortDirection || "asc") as "asc" | "desc"
     startTransition(() => {
       navigate({

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/index.tsx
@@ -195,6 +195,9 @@ export const SwiftContainers = () => {
           comparison = a.bytes - b.bytes
           break
         case "last_modified": {
+          // Both missing → equal (keeps the comparator transitive); exactly one
+          // missing → push it to the end.
+          if (!a.last_modified && !b.last_modified) return 0
           if (!a.last_modified || !b.last_modified) {
             return a.last_modified ? -1 : 1
           }

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Containers/index.tsx
@@ -230,10 +230,7 @@ export const SwiftContainers = () => {
 
   const handleSortChange = (newSortSettings: SortSettings) => {
     const resolvedSortBy = (newSortSettings.sortBy?.toString() || "name") as
-      | "name"
-      | "count"
-      | "bytes"
-      | "last_modified"
+      "name" | "count" | "bytes" | "last_modified"
     const resolvedDirection = (newSortSettings.sortDirection || "asc") as "asc" | "desc"
     startTransition(() => {
       navigate({

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/EditObjectMetadataModal.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/EditObjectMetadataModal.tsx
@@ -15,6 +15,7 @@ import {
 } from "@cloudoperators/juno-ui-components"
 import { useParams } from "@tanstack/react-router"
 import { formatBytesBinary } from "@/client/utils/formatBytes"
+import { formatSwiftDate } from "@/client/utils/formatSwiftDate"
 import { ObjectRow } from "./"
 
 // ── Types ──────────────────────────────────────────────────────────────────────
@@ -73,18 +74,18 @@ const validateMetaKey = (key: string): MetaKeyError | null => {
   return null
 }
 
-const formatDate = (iso: string): string => {
-  const date = new Date(iso)
-  if (isNaN(date.getTime())) return "—"
-  return date.toLocaleString(undefined, {
+const formatDate = (iso: string): string =>
+  // #1236: Swift timestamps are UTC without a "Z"; parse them as UTC (via
+  // formatSwiftDate) so the value is correct. This view intentionally displays
+  // in UTC (timeZone: "UTC"), unlike the list tables which show local time.
+  formatSwiftDate(iso, undefined, {
     year: "numeric",
     month: "short",
     day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
     timeZone: "UTC",
-  })
-}
+  }) ?? "—"
 
 // Converts a Unix timestamp (seconds) to the "YYYY-MM-DD HH:mm:ss" field format (UTC)
 const formatUnixToTimestamp = (unix: number): string => {

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/ObjectsTableView.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/ObjectsTableView.tsx
@@ -19,6 +19,7 @@ import {
 import { Trans, useLingui } from "@lingui/react/macro"
 import { MdFolder, MdDescription } from "react-icons/md"
 import { formatBytesBinary } from "@/client/utils/formatBytes"
+import { formatSwiftDate } from "@/client/utils/formatSwiftDate"
 import { trpcReact } from "@/client/trpcClient"
 import { useProjectId } from "@/client/hooks/useProjectId"
 import { useVirtualizedTableBody } from "@/client/hooks/useVirtualizedTableBody"
@@ -208,11 +209,6 @@ export const ObjectsTableView = ({
     }
   }, [rows.length, bodyHeight])
 
-  // Format date to localized string
-  const formatDate = (dateString: string): string => {
-    const d = new Date(dateString)
-    return Number.isNaN(d.getTime()) ? t`N/A` : d.toLocaleString()
-  }
   // Only object rows (not folders) are selectable
   const handleSelectObject = (name: string) => {
     if (selectedObjects.includes(name)) {
@@ -411,7 +407,7 @@ export const ObjectsTableView = ({
                         </button>
                       </div>
                     ) : !isFolder && row.last_modified ? (
-                      formatDate(row.last_modified)
+                      (formatSwiftDate(row.last_modified) ?? "—")
                     ) : (
                       "—"
                     )}

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/index.tsx
@@ -356,8 +356,12 @@ export const SwiftObjects = ({ provider, containerName }: { provider: string; co
             const bDate = b.kind === "object" ? b.last_modified : undefined
             if (!aDate || !bDate) break
             // #1236: Swift listing timestamps are UTC without a "Z" — parse them
-            // as UTC so the ordering is correct (matters near DST boundaries).
-            comparison = (parseSwiftDate(aDate)?.getTime() ?? 0) - (parseSwiftDate(bDate)?.getTime() ?? 0)
+            // as UTC so the ordering is correct (matters near DST boundaries). If
+            // a (non-empty) value can't be parsed, leave the pair as equal so the
+            // order is untouched (matches the old NaN behaviour).
+            const at = parseSwiftDate(aDate)?.getTime()
+            const bt = parseSwiftDate(bDate)?.getTime()
+            comparison = at == null || bt == null ? 0 : at - bt
             break
           }
           case "bytes": {

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/index.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/storage/-components/Swift/Objects/index.tsx
@@ -17,6 +17,7 @@ import {
 import { trpcReact } from "@/client/trpcClient"
 import { useProjectId } from "@/client/hooks/useProjectId"
 import { ObjectSummary } from "@/server/Storage/types/swift"
+import { parseSwiftDate } from "@/client/utils/formatSwiftDate"
 import { SortInput } from "@/client/components/ListToolbar/SortInput"
 import { SortSettings } from "@/client/components/ListToolbar/types"
 import { useNavigate } from "@tanstack/react-router"
@@ -354,7 +355,9 @@ export const SwiftObjects = ({ provider, containerName }: { provider: string; co
             const aDate = a.kind === "object" ? a.last_modified : undefined
             const bDate = b.kind === "object" ? b.last_modified : undefined
             if (!aDate || !bDate) break
-            comparison = new Date(aDate).getTime() - new Date(bDate).getTime()
+            // #1236: Swift listing timestamps are UTC without a "Z" — parse them
+            // as UTC so the ordering is correct (matters near DST boundaries).
+            comparison = (parseSwiftDate(aDate)?.getTime() ?? 0) - (parseSwiftDate(bDate)?.getTime() ?? 0)
             break
           }
           case "bytes": {

--- a/packages/aurora/src/client/utils/formatSwiftDate.test.ts
+++ b/packages/aurora/src/client/utils/formatSwiftDate.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from "vitest"
+import { parseSwiftDate, formatSwiftDate } from "./formatSwiftDate"
+
+describe("parseSwiftDate", () => {
+  test("treats a zone-less Swift timestamp as UTC (the #1236 fix)", () => {
+    // "2024-03-01T08:00:00.000000" is UTC per Swift, but has no "Z". Without the
+    // fix, new Date() would read it as local time. We assert the parsed instant
+    // is 08:00 UTC — timezone-independent, so the test is deterministic.
+    const date = parseSwiftDate("2024-03-01T08:00:00.000000")
+    expect(date?.toISOString()).toBe("2024-03-01T08:00:00.000Z")
+  })
+
+  test("handles microsecond precision", () => {
+    const date = parseSwiftDate("2024-03-01T08:00:00.435654031")
+    // Engines keep millisecond precision; the instant is still 08:00:00.435 UTC.
+    expect(date?.toISOString()).toBe("2024-03-01T08:00:00.435Z")
+  })
+
+  test("leaves a timestamp that already has a Z untouched (e.g. Ceph)", () => {
+    const date = parseSwiftDate("2024-03-01T08:00:00Z")
+    expect(date?.toISOString()).toBe("2024-03-01T08:00:00.000Z")
+  })
+
+  test("respects an explicit offset instead of forcing UTC", () => {
+    const date = parseSwiftDate("2024-03-01T08:00:00+02:00")
+    // 08:00 at +02:00 is 06:00 UTC.
+    expect(date?.toISOString()).toBe("2024-03-01T06:00:00.000Z")
+  })
+
+  test("parses a date-only string as UTC without breaking it", () => {
+    const date = parseSwiftDate("2024-03-01")
+    expect(date?.toISOString()).toBe("2024-03-01T00:00:00.000Z")
+  })
+
+  test("returns null for empty, undefined, or invalid input", () => {
+    expect(parseSwiftDate(undefined)).toBeNull()
+    expect(parseSwiftDate(null)).toBeNull()
+    expect(parseSwiftDate("")).toBeNull()
+    expect(parseSwiftDate("   ")).toBeNull()
+    expect(parseSwiftDate("not a date")).toBeNull()
+  })
+})
+
+describe("formatSwiftDate", () => {
+  const timeOpts: Intl.DateTimeFormatOptions = { hour: "2-digit", minute: "2-digit", hour12: false }
+
+  test("renders the zone-less UTC timestamp converted to the target timezone", () => {
+    // Same instant (08:00 UTC), shown in two zones — proves the UTC→local
+    // conversion actually happens.
+    expect(formatSwiftDate("2024-03-01T08:00:00.000000", "en-US", { ...timeOpts, timeZone: "UTC" })).toBe("08:00")
+    // New York on 2024-03-01 is EST (UTC-5; DST starts Mar 10), so 08:00 UTC → 03:00.
+    expect(formatSwiftDate("2024-03-01T08:00:00.000000", "en-US", { ...timeOpts, timeZone: "America/New_York" })).toBe(
+      "03:00"
+    )
+  })
+
+  test("returns null for missing/invalid input so callers can supply a fallback", () => {
+    expect(formatSwiftDate(undefined)).toBeNull()
+    expect(formatSwiftDate("")).toBeNull()
+    expect(formatSwiftDate("nope")).toBeNull()
+  })
+})

--- a/packages/aurora/src/client/utils/formatSwiftDate.test.ts
+++ b/packages/aurora/src/client/utils/formatSwiftDate.test.ts
@@ -10,8 +10,8 @@ describe("parseSwiftDate", () => {
     expect(date?.toISOString()).toBe("2024-03-01T08:00:00.000Z")
   })
 
-  test("handles microsecond precision", () => {
-    const date = parseSwiftDate("2024-03-01T08:00:00.435654031")
+  test("handles fractional seconds beyond milliseconds (truncates to ms)", () => {
+    const date = parseSwiftDate("2024-03-01T08:00:00.435654")
     // Engines keep millisecond precision; the instant is still 08:00:00.435 UTC.
     expect(date?.toISOString()).toBe("2024-03-01T08:00:00.435Z")
   })

--- a/packages/aurora/src/client/utils/formatSwiftDate.ts
+++ b/packages/aurora/src/client/utils/formatSwiftDate.ts
@@ -1,0 +1,56 @@
+/**
+ * Swift timestamp helpers.
+ *
+ * Swift returns `last_modified` in container and object listings as an ISO 8601
+ * timestamp that is UTC but carries NO zone designator — e.g.
+ * "2024-03-01T08:00:00.000000" (see OpenStack Swift bug #1169287: dates in the
+ * JSON listings are UTC without a trailing "Z"). Per ISO 8601, a date-time with
+ * no zone is interpreted as LOCAL time, so `new Date("...T08:00:00")` treats the
+ * value as local and the rendered time ends up shifted by the viewer's UTC
+ * offset (#1236).
+ *
+ * These helpers treat a zone-less timestamp as UTC (by appending "Z" before
+ * parsing) so it converts correctly to the viewer's local time. Timestamps that
+ * already carry a zone — a trailing "Z" or an explicit ±hh:mm offset, as Ceph
+ * returns — are left untouched.
+ */
+
+// Matches a zone designator at the end of the string: "Z", or an offset like
+// "+02:00" / "-0500". The date part's own hyphens can't match because of the `$`
+// anchor.
+const HAS_ZONE = /(Z|[+-]\d{2}:?\d{2})$/
+
+/**
+ * Parse a Swift timestamp into a Date, treating a zone-less value as UTC.
+ * Returns null for empty or unparseable input.
+ */
+export const parseSwiftDate = (value: string | null | undefined): Date | null => {
+  if (!value) return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  // Only a full date-time (has a "T") that lacks a zone needs normalizing to
+  // UTC. A date-only string ("2024-03-01") is already parsed as UTC by the
+  // engine, and appending "Z" to it would make it invalid.
+  const needsUtc = trimmed.includes("T") && !HAS_ZONE.test(trimmed)
+  const normalized = needsUtc ? `${trimmed}Z` : trimmed
+
+  const date = new Date(normalized)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+/**
+ * Format a Swift timestamp in the viewer's local timezone.
+ *
+ * Returns null for empty/invalid input so callers can supply their own fallback
+ * (e.g. a translated "N/A"). `locales`/`options` are passed straight through to
+ * `Date.prototype.toLocaleString`.
+ */
+export const formatSwiftDate = (
+  value: string | null | undefined,
+  locales?: Intl.LocalesArgument,
+  options?: Intl.DateTimeFormatOptions
+): string | null => {
+  const date = parseSwiftDate(value)
+  return date ? date.toLocaleString(locales, options) : null
+}

--- a/packages/aurora/src/client/utils/formatSwiftDate.ts
+++ b/packages/aurora/src/client/utils/formatSwiftDate.ts
@@ -40,7 +40,8 @@ export const parseSwiftDate = (value: string | null | undefined): Date | null =>
 }
 
 /**
- * Format a Swift timestamp in the viewer's local timezone.
+ * Format a Swift timestamp, defaulting to the viewer's local timezone (unless
+ * overridden via `options.timeZone`).
  *
  * Returns null for empty/invalid input so callers can supply their own fallback
  * (e.g. a translated "N/A"). `locales`/`options` are passed straight through to


### PR DESCRIPTION
## What

Add a shared Swift timestamp helper and use it in the container and object
tables, so `last_modified` renders in the viewer's local timezone.

Closes #1236.

## Why

Swift returns `last_modified` in its JSON listings as a UTC ISO 8601 timestamp
**without a zone designator** (e.g. `2024-03-01T08:00:00.000000`) — see Swift
bug #1169287. Per ISO 8601, a date-time with no zone is parsed as **local**
time, so `new Date("...T08:00:00").toLocaleString()` skipped the UTC→local
conversion and showed the time shifted by the viewer's offset.

## Changes

- New `@/client/utils/formatSwiftDate.ts`:
  - `parseSwiftDate` — appends `Z` to a zone-less date-time (treat as UTC),
    leaves already-zoned timestamps (Ceph's `…Z`, explicit offsets) and
    date-only strings untouched; returns `null` for empty/invalid.
  - `formatSwiftDate` — `toLocaleString` wrapper returning `null` for invalid so
    callers keep their own fallback.
- `ContainerTableView` / `ObjectsTableView` (Swift): dropped their local
  `formatDate` and use `formatSwiftDate` (fallbacks: `N/A` / `—`).
- Added `formatSwiftDate.test.ts` with timezone-independent assertions.

## Notes

- Ceph is unaffected — it already returns zoned timestamps, which the helper
  passes through unchanged. Scope is Swift, per the issue.
- Existing table tests don't assert a concrete date string (they note it's
  locale-dependent), so they stay green.

## Testing

- [x] Unit tests for `parseSwiftDate` / `formatSwiftDate`
- [x] Swift container/object times render in the local timezone (e.g. CET/CEST)
- [x] Missing timestamps still show N/A (containers) / — (objects)

## Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
