### PR TITLE
fix(aurora): remove bad changeset

### DIFF
--- a/.changeset/fix-tmp-vulnerability.md
+++ b/.changeset/fix-tmp-vulnerability.md
@@ -1,7 +1,0 @@
----
-"@cobaltcore-dev/aurora-dashboard": patch
----
-
-fix: resolve tmp path traversal vulnerability (CVE) via pnpm override
-
-Override transitive dependency `tmp@<0.2.6` to `>=0.2.6` to fix a path traversal vulnerability that allows escaping the temporary directory via unsanitized prefix/postfix options. The vulnerable version was pulled in through `cz-customizable → inquirer → external-editor → tmp@0.0.33`.


### PR DESCRIPTION
# Summary

Remove an invalid changeset that was accidentally created for `@cobaltcore-dev/aurora-dashboard` (the root `package.json`) in PR #1269. The root package is not part of the pnpm workspace and is not recognized by changesets, causing the automated Release workflow to fail with:

> Error: Found changeset fix-tmp-vulnerability for package @cobaltcore-dev/aurora-dashboard which is not in the workspace

# Changes Made

- Remove `.changeset/fix-tmp-vulnerability.md`

# Related Issues

- Caused by: #1269

# Screenshots (if applicable)

N/A

# Testing Instructions

1. `pnpm i`
2. Verify the Release workflow passes after merge

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
