### PR TITLE
fix(aurora): ensure single primary action button per page

### DIFF
--- a/.changeset/single-primary-action.md
+++ b/.changeset/single-primary-action.md
@@ -1,0 +1,5 @@
+---
+"@cobaltcore-dev/aurora": patch
+---
+
+Ensure single primary action button per page on flavor and image detail views

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/flavors/$flavorId.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/flavors/$flavorId.tsx
@@ -193,7 +193,7 @@ function RouteComponent() {
       {(canManageAccess || canDeleteFlavor) && (
         <PopupMenu>
           <PopupMenuToggle as="div">
-            <Button icon="moreVert">{/* <Trans>More Actions</Trans> */}</Button>
+            <Button icon="moreVert" title={t`More Actions`} />
           </PopupMenuToggle>
           <PopupMenuOptions>
             {canManageAccess && (

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/flavors/$flavorId.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/flavors/$flavorId.tsx
@@ -189,24 +189,26 @@ function RouteComponent() {
   const hasMoreActions = canManageAccess || canDeleteFlavor || canManageSpecs || canListSpecs
 
   const headerActions = hasMoreActions ? (
-    <ButtonRow>
-      <PopupMenu>
-        <PopupMenuToggle as="div">
-          <Button icon="moreVert">
-            <Trans>More Actions</Trans>
-          </Button>
-        </PopupMenuToggle>
-        <PopupMenuOptions>
-          {(canManageSpecs || canListSpecs) && (
-            <PopupMenuItem label={canManageSpecs ? t`Edit Metadata` : t`Metadata`} onClick={toggleSpecModal} />
-          )}
-          {canManageAccess && (
-            <PopupMenuItem label={t`Manage Access`} onClick={toggleAccessModal} disabled={isPublicFlavor} />
-          )}
-          {canDeleteFlavor && <PopupMenuItem label={t`Delete Flavor`} onClick={toggleDeleteModal} />}
-        </PopupMenuOptions>
-      </PopupMenu>
-    </ButtonRow>
+    <Stack gap="0.5" alignment="center">
+      {(canManageAccess || canDeleteFlavor) && (
+        <PopupMenu>
+          <PopupMenuToggle as="div">
+            <Button icon="moreVert">{/* <Trans>More Actions</Trans> */}</Button>
+          </PopupMenuToggle>
+          <PopupMenuOptions>
+            {canManageAccess && (
+              <PopupMenuItem label={t`Manage Access`} onClick={toggleAccessModal} disabled={isPublicFlavor} />
+            )}
+            {canDeleteFlavor && <PopupMenuItem label={t`Delete Flavor`} onClick={toggleDeleteModal} />}
+          </PopupMenuOptions>
+        </PopupMenu>
+      )}
+      {(canManageSpecs || canListSpecs) && (
+        <Button variant="primary" onClick={toggleSpecModal}>
+          {canManageSpecs ? <Trans>Edit Metadata</Trans> : <Trans>Metadata</Trans>}
+        </Button>
+      )}
+    </Stack>
   ) : undefined
 
   return (

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/flavors/-components/List.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/flavors/-components/List.tsx
@@ -143,7 +143,7 @@ function FlavorsContent({
 
       {/* Zone 1 — sort + create action, no background */}
       <Stack distribution="end" alignment="center" gap="2" className="pb-2">
-        <Stack gap="0.5">
+        <Stack gap="2">
           <SortInput
             options={sortSettings.options}
             sortBy={sortSettings.sortBy}

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/$imageId.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/$imageId.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  ButtonRow,
   Stack,
   Status,
   PopupMenu,
@@ -350,67 +349,68 @@ function RouteComponent() {
 
   const hasMoreActions = canRejectSharedImage || canUpdateOwnImage || canDeleteOwnImage || canManageSharing
 
-  const headerActions =
-    hasMoreActions || (!isSharedWithMe && permissions.canUpdate) ? (
-      <ButtonRow>
-        {hasMoreActions && (
-          <PopupMenu>
-            <PopupMenuToggle as="div">
-              <Button icon="moreVert" disabled={isLoading}>
-                <Trans>More Actions</Trans>
-              </Button>
-            </PopupMenuToggle>
-            <PopupMenuOptions>
-              {canRejectSharedImage && (
-                <PopupMenuItem label={t`Reject`} onClick={() => handleMemberStatusChange("rejected")} />
-              )}
-              {!isSharedWithMe && permissions.canUpdate && (
+  const headerActions = (
+    <Stack gap="0.5" alignment="center">
+      {(hasMoreActions || (!isSharedWithMe && permissions.canUpdate)) && (
+        <PopupMenu className="flex items-center">
+          <PopupMenuToggle as="div">
+            <Button icon="moreVert" title={t`More Actions`} />
+          </PopupMenuToggle>
+          <PopupMenuOptions>
+            {!isSharedWithMe && permissions.canUpdate && (
+              <PopupMenuItem
+                onClick={() => setEditMetadataModalOpen(true)}
+                label={t`Edit Metadata`}
+                disabled={isLoading}
+              />
+            )}
+            {canRejectSharedImage && (
+              <PopupMenuItem label={t`Reject`} onClick={() => handleMemberStatusChange("rejected")} />
+            )}
+            {!isSharedWithMe && permissions.canUpdate && (
+              <PopupMenuItem
+                label={isDeactivated ? t`Activate` : t`Deactivate`}
+                onClick={() => (isDeactivated ? setActivateModalOpen(true) : setDeactivateModalOpen(true))}
+              />
+            )}
+            {!isSharedWithMe && permissions.canUpdate && isPrivate && (
+              <PopupMenuItem label={t`Set to "Shared"`} onClick={() => handleUpdateVisibility("shared")} />
+            )}
+            {!isSharedWithMe &&
+              isImageOwner &&
+              image.visibility === IMAGE_VISIBILITY.SHARED &&
+              (permissions.canCreateMember || permissions.canDeleteMember) && (
                 <PopupMenuItem
-                  label={isDeactivated ? t`Activate` : t`Deactivate`}
-                  onClick={() => (isDeactivated ? setActivateModalOpen(true) : setDeactivateModalOpen(true))}
+                  label={t`Manage Access`}
+                  onClick={() =>
+                    navigate({
+                      to: "/projects/$projectId/compute/images/$imageId",
+                      params: { projectId, imageId: image.id },
+                      search: { tab: "sharing" },
+                    })
+                  }
                 />
               )}
-              {!isSharedWithMe && permissions.canUpdate && isPrivate && (
-                <PopupMenuItem label={t`Set to "Shared"`} onClick={() => handleUpdateVisibility("shared")} />
-              )}
-              {!isSharedWithMe &&
-                isImageOwner &&
-                image.visibility === IMAGE_VISIBILITY.SHARED &&
-                (permissions.canCreateMember || permissions.canDeleteMember) && (
-                  <PopupMenuItem
-                    label={t`Manage Access`}
-                    onClick={() =>
-                      navigate({
-                        to: "/projects/$projectId/compute/images/$imageId",
-                        params: { projectId, imageId: image.id },
-                        search: { tab: "sharing" },
-                      })
-                    }
-                  />
-                )}
-              {!isSharedWithMe && permissions.canDelete && !image.protected && (
-                <PopupMenuItem label={t`Delete`} onClick={() => setDeleteModalOpen(true)} />
-              )}
-            </PopupMenuOptions>
-          </PopupMenu>
-        )}
-        {!isSharedWithMe && permissions.canUpdate && (
-          <Button onClick={() => setEditMetadataModalOpen(true)} disabled={isLoading}>
-            <Trans>Edit Metadata</Trans>
-          </Button>
-        )}
-        {!isSharedWithMe && permissions.canUpdate && (
-          <Button onClick={() => setEditDetailsModalOpen(true)} variant="primary" disabled={isLoading}>
-            <Trans>Edit Details</Trans>
-          </Button>
-        )}
-      </ButtonRow>
-    ) : undefined
+            {!isSharedWithMe && permissions.canDelete && !image.protected && (
+              <PopupMenuItem label={t`Delete`} onClick={() => setDeleteModalOpen(true)} />
+            )}
+          </PopupMenuOptions>
+        </PopupMenu>
+      )}
+
+      {!isSharedWithMe && permissions.canUpdate && (
+        <Button onClick={() => setEditDetailsModalOpen(true)} variant="primary" disabled={isLoading}>
+          <Trans>Edit Details</Trans>
+        </Button>
+      )}
+    </Stack>
+  )
 
   // Render success state
   return (
     <>
       <ContentHeader title={String(image.name ?? image.id)} projectId={projectId} actions={headerActions} />
+
       <div className="mt-3">
         <ImageDetailsView
           key={image.id}

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/$imageId.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/$imageId.tsx
@@ -354,7 +354,7 @@ const headerActions = (hasMoreActions || (!isSharedWithMe && permissions.canUpda
       {(hasMoreActions || (!isSharedWithMe && permissions.canUpdate)) && (
         <PopupMenu className="flex items-center">
           <PopupMenuToggle as="div">
-            <Button icon="moreVert" title={t`More Actions`} />
+            <Button icon="moreVert" title={t`More Actions`} disabled={isLoading} />
           </PopupMenuToggle>
           <PopupMenuOptions>
             {!isSharedWithMe && permissions.canUpdate && (

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/$imageId.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/$imageId.tsx
@@ -349,7 +349,7 @@ function RouteComponent() {
 
   const hasMoreActions = canRejectSharedImage || canUpdateOwnImage || canDeleteOwnImage || canManageSharing
 
-const headerActions = (hasMoreActions || (!isSharedWithMe && permissions.canUpdate)) && (
+  const headerActions = (hasMoreActions || (!isSharedWithMe && permissions.canUpdate)) && (
     <Stack gap="0.5" alignment="center">
       {(hasMoreActions || (!isSharedWithMe && permissions.canUpdate)) && (
         <PopupMenu className="flex items-center">

--- a/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/$imageId.tsx
+++ b/packages/aurora/src/client/routes/_auth/projects/$projectId/compute/images/$imageId.tsx
@@ -349,7 +349,7 @@ function RouteComponent() {
 
   const hasMoreActions = canRejectSharedImage || canUpdateOwnImage || canDeleteOwnImage || canManageSharing
 
-  const headerActions = (
+const headerActions = (hasMoreActions || (!isSharedWithMe && permissions.canUpdate)) && (
     <Stack gap="0.5" alignment="center">
       {(hasMoreActions || (!isSharedWithMe && permissions.canUpdate)) && (
         <PopupMenu className="flex items-center">


### PR DESCRIPTION
## Summary

Refactored flavor detail and image detail pages to have only one primary action button, improving UX consistency per design guidelines.

## Changes

### Flavor Detail Page (`$flavorId.tsx`)
- Made **Edit Metadata** the primary action button
- Moved **Manage Access** and **Delete Flavor** into a more-actions dropdown menu (icon-only button)

### Image Detail Page (`$imageId.tsx`)
- Made **Edit Details** the sole primary action button
- Moved **Edit Metadata** into the more-actions dropdown menu

### Flavor List (`List.tsx`)
- Adjusted button spacing for better visual alignment

## Related Issue

Closes #1166